### PR TITLE
docs: correct typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <img src="https://github.com/user-attachments/assets/8b28b10f-495a-4cf7-8ec8-43c4cf684db8">
   <p>
     <b>
-      Modular and lighting-fast Python-Rust Bundler for Ethereum EIP-4337 Account Abstraction
+      Modular and lightning-fast Python-Rust Bundler for Ethereum EIP-4337 Account Abstraction
     </b>
    </p>
 </div>
@@ -50,7 +50,7 @@ Follow the installation guide to install [docker on ubuntu](https://docs.docker.
 
 ### Post docker installation
 
-Follow the instruction for docker's [post linux instalation](https://docs.docker.com/engine/install/linux-postinstall/)  
+Follow the instruction for docker's [post linux installation](https://docs.docker.com/engine/install/linux-postinstall/)  
 
 ### Start geth
 ```
@@ -120,4 +120,4 @@ None of this would have been possible without the following teams and organizati
 * <a href='https://eips.ethereum.org/EIPS/eip-4337'>EIP-4337: Account Abstraction via Entry Point Contract specification </a>
 * <a href='https://github.com/eth-infinitism/bundler'>eth-infinitism/bundler</a>
 * <a href='https://github.com/sigp/lighthouse'>Lighthouse: Ethereum consensus client</a>
-* [The Ethereum Foundation](https://ethereum.foundation/) throught the Ecosystem Support Grants Program (ESP).
+* [The Ethereum Foundation](https://ethereum.foundation/) through the Ecosystem Support Grants Program (ESP).


### PR DESCRIPTION
This PR fixes three obvious typos in the README
lighting fast → lightning fast
instalation → installation
throught → through
No behavioral changes. Only documentation.