### PR TITLE
feat: add RPC path to CLI args

### DIFF
--- a/voltaire_bundler/cli_manager.py
+++ b/voltaire_bundler/cli_manager.py
@@ -57,6 +57,7 @@ class InitData:
     max_priority_fee_per_gas_percentage_multiplier: int
     is_metrics: bool
     rpc_cors_domain: str
+    rpc_path: str
     enforce_gas_price_tolerance: int
     ethereum_node_debug_trace_call_urls: list[str]
     ethereum_node_eth_get_logs_urls: list[str]
@@ -178,6 +179,15 @@ def initialize_argument_parser() -> ArgumentParser:
         nargs="?",
         const="*",
         default=_get_env_or_default("VOLTAIRE_RPC_CORS_DOMAIN", "*", str),
+    )
+
+    parser.add_argument(
+        "--rpc_path",
+        type=str,
+        help="RPC serve path - defaults to '/rpc'",
+        nargs="?",
+        const="/rpc",
+        default=_get_env_or_default("VOLTAIRE_RPC_PATH", "/rpc", str),
     )
 
     parser.add_argument(
@@ -911,6 +921,7 @@ async def get_init_data(args: Namespace) -> InitData:
         args.max_priority_fee_per_gas_percentage_multiplier,
         args.metrics,
         args.rpc_cors_domain,
+        args.rpc_path,
         args.enforce_gas_price_tolerance,
         ethereum_node_debug_trace_call_urls,
         ethereum_node_eth_get_logs_urls,

--- a/voltaire_bundler/cli_manager.py
+++ b/voltaire_bundler/cli_manager.py
@@ -103,6 +103,15 @@ def unsigned_int(value):
     return ivalue
 
 
+def rpc_path(value: str):
+    if not value.startswith("/"):
+        value = "/" + value
+    path_pattern = r"^(/[a-zA-Z0-9._~:@!$&'()*+,;=\-]*)+$"
+    if not re.match(path_pattern, value):
+        raise ArgumentTypeError(f"Invalid RPC path: {value}")
+    return value
+
+
 def url_no_port(ep: str):
     address_pattern = "^(((https|http)://)?((?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|(?:\\d{1,3}\\.){3}\\d{1,3}))$"
     if not isinstance(ep, str) or re.match(address_pattern, ep) is None:
@@ -183,11 +192,11 @@ def initialize_argument_parser() -> ArgumentParser:
 
     parser.add_argument(
         "--rpc_path",
-        type=str,
+        type=rpc_path,
         help="RPC serve path - defaults to '/rpc'",
         nargs="?",
         const="/rpc",
-        default=_get_env_or_default("VOLTAIRE_RPC_PATH", "/rpc", str),
+        default=_get_env_or_default("VOLTAIRE_RPC_PATH", "/rpc", rpc_path),
     )
 
     parser.add_argument(

--- a/voltaire_bundler/main.py
+++ b/voltaire_bundler/main.py
@@ -105,6 +105,7 @@ async def main(cmd_args=sys.argv[1:], loop=None) -> None:
                     host=init_data.rpc_url,
                     rpc_cors_domain=init_data.rpc_cors_domain,
                     port=init_data.rpc_port,
+                    rpc_path=init_data.rpc_path,
                     is_debug=init_data.is_debug,
                 )
             )

--- a/voltaire_bundler/rpc/rpc_http_server.py
+++ b/voltaire_bundler/rpc/rpc_http_server.py
@@ -379,6 +379,7 @@ async def run_rpc_http_server(
     host: str = "localhost",
     rpc_cors_domain: str = "*",
     port: int = 3000,
+    rpc_path: str = "/rpc",
     is_debug: bool = False,
 ) -> None:
     if is_debug:
@@ -394,9 +395,9 @@ async def run_rpc_http_server(
         }
         METHODS.update(debug_methods)
 
-    logging.info(f"Starting HTTP RPC Server at: {host}:{port}/rpc")
+    logging.info(f"Starting HTTP RPC Server at: {host}:{port}{rpc_path}")
     app = web.Application()
-    app.router.add_post("/rpc", handle)
+    app.router.add_post(rpc_path, handle)
 
     app.router.add_post(
         "/health",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --rpc_path command-line option (and VOLTAIRE_RPC_PATH env fallback) to configure the RPC HTTP endpoint instead of a hardcoded path.
  * The RPC HTTP server now uses and reports the configured endpoint at startup, ensuring routing and logs reflect the chosen path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->