### PR TITLE
update error message for failing to replace useroperation

### DIFF
--- a/voltaire_bundler/mempool/sender_mempool.py
+++ b/voltaire_bundler/mempool/sender_mempool.py
@@ -81,7 +81,7 @@ class SenderMempool:
         else:
             raise ValidationException(
                 ValidationExceptionCode.InvalidFields,
-                "invalid UserOperation struct/fields",
+                "invalid UserOperation struct/fields (can't replace useroperation)",
             )
 
     @staticmethod

--- a/voltaire_bundler/mempool/sender_mempool.py
+++ b/voltaire_bundler/mempool/sender_mempool.py
@@ -79,9 +79,20 @@ class SenderMempool:
                 old_paymaster
             )
         else:
+            existing_operation = self.user_operation_hashs_to_verified_user_operation[
+                existing_user_operation_hash_with_same_nonce
+            ].user_operation
             raise ValidationException(
                 ValidationExceptionCode.InvalidFields,
-                "invalid UserOperation struct/fields (can't replace useroperation)",
+                (
+                    f"invalid UserOperation struct/fields: a UserOperation with nonce "
+                    f"{hex(new_user_operation.nonce)} is already in the mempool for sender "
+                    f"{self.address} (maxFeePerGas: {hex(existing_operation.max_fee_per_gas)}, "
+                    f"maxPriorityFeePerGas: {hex(existing_operation.max_priority_fee_per_gas)}). "
+                    f"Wait for it to be included onchain; only resend if it fails. "
+                    f"To replace it, resubmit with both maxFeePerGas and maxPriorityFeePerGas "
+                    f"at least {MIN_PRICE_BUMP}% higher."
+                ),
             )
 
     @staticmethod


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure messaging when a user operation replacement is rejected: the message now identifies that another operation with the same nonce/sender is already in the mempool and explains the expected fee increase and replacement requirements to help users correct and retry their submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->