### PR TITLE
Tiered RPC-result cache (in-memory FIFO + optional SQLite cold tier) behind eth_getUserOperationByHash and eth_getUserOperationReceipt

### DIFF
--- a/tests/test_cache_shutdown_race.py
+++ b/tests/test_cache_shutdown_race.py
@@ -1,0 +1,197 @@
+"""
+Concurrency regression for PersistentFIFOCache._close_conns.
+
+Earlier, _close_conns / _disable_disk_tier closed self._read_conn and
+nulled it without holding self._read_lock, while _disk_get and
+_disk_get_many checked _read_conn outside the lock and used it inside.
+A reader that passed the None-check while a sibling reader was in the
+malformed-JSON path (which calls _disable_disk_tier after releasing the
+lock) could then call .execute() on a now-closed connection and surface
+a sqlite3.ProgrammingError("Cannot operate on a closed database.").
+
+The fix: _close_conns acquires _read_lock around the read-conn
+close+null, and _disk_get/_disk_get_many do the None check INSIDE the
+lock. This test stresses the race by running many concurrent reader
+threads while one of them dereferences a malformed-JSON row that
+triggers _disable_disk_tier, and asserts no sqlite exception is raised.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from voltaire_bundler.utils.cache import PersistentFIFOCache
+
+
+def _seed_rows(db_path: Path, table: str) -> None:
+    """Side-channel insert of one decodable and one malformed-JSON row.
+
+    Going via a separate sqlite3 connection (rather than cache.set) means
+    the malformed row never passes through the writer task's JSON
+    encoder; _warm_memory_from_disk has also already finished by the
+    time we call this, so it won't decode the bad row and disable the
+    tier before the race window opens."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            f"INSERT INTO {table} (key, value, seq) VALUES (?, ?, ?)",
+            ("good", b'"hello"', 9000),
+        )
+        conn.execute(
+            f"INSERT INTO {table} (key, value, seq) VALUES (?, ?, ?)",
+            ("bad", b"not-valid-json", 9001),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _drop_from_registry(cache: PersistentFIFOCache) -> None:
+    """Avoid leaking test instances into the class-level registry — other
+    tests using start_all/aclose_all would otherwise pick them up."""
+    if cache in PersistentFIFOCache._instances:
+        PersistentFIFOCache._instances.remove(cache)
+
+
+def _race_readers_against_disable(
+    cache: PersistentFIFOCache,
+) -> list[BaseException]:
+    """Spawn N reader threads hammering _disk_get/_disk_get_many on
+    "good", plus one thread that triggers _disable_disk_tier via the
+    malformed "bad" row. Returns a list of sqlite exceptions seen by any
+    thread — must be empty for the test to pass."""
+    errors: list[BaseException] = []
+    stop = threading.Event()
+
+    def hammer_good() -> None:
+        # Drive both code paths (single + bulk lookup) since each has
+        # its own None-check / lock sequence to verify.
+        while not stop.is_set():
+            try:
+                cache._disk_get("good")
+                cache._disk_get_many(["good", "missing"])
+            except sqlite3.Error as exc:
+                errors.append(exc)
+                return
+
+    def trigger_disable() -> None:
+        # Reading "bad" forces a JSONDecodeError inside _disk_get, which
+        # calls _disable_disk_tier -> _close_conns. The buggy version
+        # closes _read_conn without the lock, racing the readers above.
+        try:
+            cache._disk_get("bad")
+        except sqlite3.Error as exc:
+            errors.append(exc)
+
+    readers = [
+        threading.Thread(target=hammer_good, name=f"reader-{i}")
+        for i in range(8)
+    ]
+    for t in readers:
+        t.start()
+    # Give readers a moment to start hammering before triggering the
+    # shutdown — without this the disable can fire before any reader
+    # has even contended for the lock.
+    time.sleep(0.05)
+
+    disabler = threading.Thread(target=trigger_disable, name="disabler")
+    disabler.start()
+    disabler.join()
+
+    # Let the readers race the shutdown for a bit longer so threads that
+    # were blocked on the lock at close time get to wake up and exercise
+    # the post-close path.
+    time.sleep(0.1)
+    stop.set()
+    for t in readers:
+        t.join()
+    return errors
+
+
+@pytest.mark.asyncio
+async def test_disable_disk_tier_does_not_race_with_concurrent_reads(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "race.sqlite"
+    cache = PersistentFIFOCache(
+        name="race_test", memory_capacity=4, disk_capacity=1000,
+    )
+    try:
+        await cache.start(sqlite_path=db_path)
+        # Sanity: the disk tier opened cleanly.
+        assert cache._read_conn is not None
+        assert cache._sqlite_path is not None
+
+        _seed_rows(db_path, "race_test")
+        errors = _race_readers_against_disable(cache)
+        assert not errors, f"sqlite errors observed during shutdown: {errors!r}"
+        # Post-conditions: disk tier is fully torn down.
+        assert cache._read_conn is None
+        assert cache._sqlite_path is None
+    finally:
+        try:
+            await cache.aclose()
+        except Exception:
+            pass
+        _drop_from_registry(cache)
+
+
+@pytest.mark.asyncio
+async def test_close_conns_acquires_read_lock(tmp_path: Path) -> None:
+    """Direct, deterministic check that _close_conns waits on _read_lock.
+
+    A reader holding _read_lock must block _close_conns until it
+    releases. The stress test above can't catch every interleaving on
+    every run; this one nails down the documented invariant."""
+    db_path = tmp_path / "lock.sqlite"
+    cache = PersistentFIFOCache(name="lock_test", memory_capacity=4)
+    try:
+        await cache.start(sqlite_path=db_path)
+        assert cache._read_conn is not None
+
+        reader_inside_lock = threading.Event()
+        release_reader = threading.Event()
+
+        def hold_read_lock() -> None:
+            with cache._read_lock:
+                reader_inside_lock.set()
+                release_reader.wait(timeout=5.0)
+
+        holder = threading.Thread(target=hold_read_lock, name="lock-holder")
+        holder.start()
+        # Wait until the reader actually owns the lock.
+        assert reader_inside_lock.wait(timeout=2.0)
+
+        closer_done = threading.Event()
+
+        def close_under_contention() -> None:
+            cache._close_conns()
+            closer_done.set()
+
+        closer = threading.Thread(target=close_under_contention, name="closer")
+        closer.start()
+
+        # _close_conns must not complete while the reader holds the lock.
+        assert not closer_done.wait(timeout=0.2), (
+            "_close_conns finished while _read_lock was held — "
+            "lock is not being acquired on the close path"
+        )
+
+        release_reader.set()
+        holder.join(timeout=2.0)
+        assert closer_done.wait(timeout=2.0)
+        closer.join(timeout=2.0)
+
+        assert cache._read_conn is None
+        assert cache._write_conn is None
+    finally:
+        try:
+            await cache.aclose()
+        except Exception:
+            pass
+        _drop_from_registry(cache)

--- a/voltaire_bundler/bundle/bundle_manager.py
+++ b/voltaire_bundler/bundle/bundle_manager.py
@@ -18,8 +18,9 @@ from voltaire_bundler.mempool.mempool_manager_v8 import LocalMempoolManagerV8
 from voltaire_bundler.mempool.mempool_manager_v9 import LocalMempoolManagerV9
 from voltaire_bundler.custom_types import Address
 from voltaire_bundler.user_operation.user_operation_handler import \
-        decode_failed_op_event, decode_failed_op_with_revert_event, \
-        get_deposit_info, get_user_operation_logs_for_block_range
+        UserOperationHandler, decode_failed_op_event, \
+        decode_failed_op_with_revert_event, get_deposit_info, \
+        get_transaction_by_hash, get_user_operation_logs_for_block_range
 from voltaire_bundler.user_operation.user_operation_v6 import UserOperationV6
 from voltaire_bundler.user_operation.user_operation_v7v8v9 import UserOperationV7V8V9
 
@@ -29,6 +30,32 @@ from voltaire_bundler.utils.eth_client_utils import \
 from voltaire_bundler.utils.load_bytecode import load_bytecode
 
 from ..mempool.reputation_manager import ReputationManager
+
+
+async def _warm_inclusion_caches(
+    ethereum_node_urls: list[str],
+    user_operation_handler: UserOperationHandler,
+    transaction_hash: str,
+) -> None:
+    """Fire-and-forget warmup of ``transactions_cache`` and
+    ``transaction_receipts_cache`` once the monitor sees a userop's log
+    on-chain. By the time a client polls ``eth_getUserOperationByHash``
+    or ``eth_getUserOperationReceipt`` for this userop, both caches are
+    already warm, so the RPC handler avoids the eth_getTransactionByHash
+    and eth_getTransactionReceipt round trips against a live node.
+
+    Errors are logged and swallowed — nothing here is load-bearing; if
+    the warmup fails the caches fill lazily on the first client query."""
+    try:
+        await asyncio.gather(
+            get_transaction_by_hash(ethereum_node_urls, transaction_hash),
+            user_operation_handler.get_transaction_receipt(transaction_hash),
+        )
+    except Exception:
+        logging.exception(
+            "cache warmup after inclusion failed for tx %s",
+            transaction_hash,
+        )
 
 
 class BundlerManager:
@@ -574,6 +601,19 @@ class BundlerManager:
                 )
                 user_operations_hashes_to_remove_from_monitoring.append(
                     user_operation.user_operation_hash)
+                # Preemptively warm the tx-by-hash and tx-receipt caches in
+                # the background so the next client poll for this userop
+                # finds them hot instead of paying two more RPC round trips.
+                # The log entry's transactionHash is the only thing we need.
+                log_entry = user_operation_log[0]
+                if "transactionHash" in log_entry:
+                    asyncio.create_task(
+                        _warm_inclusion_caches(
+                            self.ethereum_node_urls,
+                            local_mempool.user_operation_handler,
+                            log_entry["transactionHash"],
+                        )
+                    )
             elif user_operation.number_of_add_to_mempool_attempts > 20:
                 logging.warning(
                     f"user operation: {user_operation.user_operation_hash} "

--- a/voltaire_bundler/bundle/bundle_manager.py
+++ b/voltaire_bundler/bundle/bundle_manager.py
@@ -586,6 +586,10 @@ class BundlerManager:
         user_operations_logs = await asyncio.gather(*logs_res_ops)
 
         user_operations_hashes_to_remove_from_monitoring = []
+        # Multiple userops in one bundle share the inclusion tx hash, so
+        # dedupe before scheduling warmups to avoid redundant RPC round
+        # trips for the same transaction.
+        seen_warmup_tx_hashes: set[str] = set()
         for user_operation, user_operation_log in zip(
             list(user_operations_to_monitor.values()), user_operations_logs
         ):
@@ -606,12 +610,14 @@ class BundlerManager:
                 # finds them hot instead of paying two more RPC round trips.
                 # The log entry's transactionHash is the only thing we need.
                 log_entry = user_operation_log[0]
-                if "transactionHash" in log_entry:
+                tx_hash = log_entry.get("transactionHash")
+                if tx_hash and tx_hash not in seen_warmup_tx_hashes:
+                    seen_warmup_tx_hashes.add(tx_hash)
                     asyncio.create_task(
                         _warm_inclusion_caches(
                             self.ethereum_node_urls,
                             local_mempool.user_operation_handler,
-                            log_entry["transactionHash"],
+                            tx_hash,
                         )
                     )
             elif user_operation.number_of_add_to_mempool_attempts > 20:

--- a/voltaire_bundler/cli_manager.py
+++ b/voltaire_bundler/cli_manager.py
@@ -92,6 +92,9 @@ class InitData:
     # into memory-only mode.
     disable_persistent_cache: bool
     cache_dir: str
+    # When True, the cache_dir is wiped at startup. One-shot flag for
+    # discarding a corrupted or stale cache.
+    clear_cache: bool
 
 
 def address(ep: str):
@@ -518,6 +521,21 @@ def initialize_argument_parser() -> ArgumentParser:
         nargs="?",
         const="",
         default=_get_env_or_default("VOLTAIRE_CACHE_DIR", "", str),
+    )
+
+    parser.add_argument(
+        "--clear_cache",
+        type=bool,
+        help=(
+            "Wipe --cache_dir before startup. One-shot flag; useful for "
+            "discarding a stale or corrupted cache without manually "
+            "deleting files. Ignored when --disable_persistent_cache is set."
+        ),
+        nargs="?",
+        const=True,
+        default=_get_env_or_default(
+            "VOLTAIRE_CLEAR_CACHE", False, lambda v: v.lower() == "true",
+        ),
     )
 
     parser.add_argument(
@@ -1021,6 +1039,7 @@ async def get_init_data(args: Namespace) -> InitData:
         args.bundle_gas_estimation_multiplier,
         args.disable_persistent_cache,
         args.cache_dir,
+        args.clear_cache,
     )
 
     if args.verbose:

--- a/voltaire_bundler/cli_manager.py
+++ b/voltaire_bundler/cli_manager.py
@@ -274,6 +274,7 @@ def initialize_argument_parser() -> ArgumentParser:
 
     parser.add_argument(
         "--verbose",
+        type=str_to_bool,
         help="show debug log",
         nargs="?",
         const=True,
@@ -282,6 +283,7 @@ def initialize_argument_parser() -> ArgumentParser:
 
     parser.add_argument(
         "--debug",
+        type=str_to_bool,
         help="expose _debug rpc namespace for testing",
         nargs="?",
         const=True,
@@ -303,6 +305,7 @@ def initialize_argument_parser() -> ArgumentParser:
 
     group2.add_argument(
         "--unsafe",
+        type=str_to_bool,
         help=(
             "UNSAFE mode: no storage or opcode checks - "
             "when debug_traceCall is not available"
@@ -325,10 +328,11 @@ def initialize_argument_parser() -> ArgumentParser:
 
     parser.add_argument(
         "--legacy_mode",
+        type=str_to_bool,
         help="for networks that doesn't support EIP-1559",
         nargs="?",
         const=True,
-        default=_get_env_or_default("VOLTAIRE_LEGACY_MODE", False, str),
+        default=_get_env_or_default("VOLTAIRE_LEGACY_MODE", False, lambda v: v.lower() == "true"),
     )
 
     group3 = parser.add_mutually_exclusive_group()
@@ -491,6 +495,7 @@ def initialize_argument_parser() -> ArgumentParser:
 
     parser.add_argument(
         "--p2p_upnp_enabled",
+        type=str_to_bool,
         help="Attempt to construct external port mappings with UPnP.",
         nargs="?",
         const=True,
@@ -499,6 +504,7 @@ def initialize_argument_parser() -> ArgumentParser:
 
     parser.add_argument(
         "--p2p_metrics_enabled",
+        type=str_to_bool,
         help="Whether metrics are enabled.",
         nargs="?",
         const=True,

--- a/voltaire_bundler/cli_manager.py
+++ b/voltaire_bundler/cli_manager.py
@@ -131,6 +131,15 @@ def positive_float(value):
     return fvalue
 
 
+def str_to_bool(value: str | bool) -> bool:
+    # argparse's built-in type=bool treats every non-empty string as True
+    # (so `--disable_p2p false` would silently disable nothing). Match the
+    # env-var lambda convention: only "true" (case-insensitive) is true.
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() == "true"
+
+
 def rpc_path(value: str):
     if not value.startswith("/"):
         value = "/" + value
@@ -411,7 +420,7 @@ def initialize_argument_parser() -> ArgumentParser:
 
     parser.add_argument(
         "--metrics",
-        type=bool,
+        type=str_to_bool,
         help="enable metrics collection",
         nargs="?",
         const=True,
@@ -426,7 +435,7 @@ def initialize_argument_parser() -> ArgumentParser:
 
     parser.add_argument(
         "--disable_v6",
-        type=bool,
+        type=str_to_bool,
         help="disable support for entrypoint v0.06",
         nargs="?",
         const=True,
@@ -498,7 +507,7 @@ def initialize_argument_parser() -> ArgumentParser:
 
     parser.add_argument(
         "--disable_p2p",
-        type=bool,
+        type=str_to_bool,
         help="disable p2p (on by default; pass VOLTAIRE_DISABLE_P2P=false to opt in)",
         nargs="?",
         const=True,
@@ -507,7 +516,7 @@ def initialize_argument_parser() -> ArgumentParser:
 
     parser.add_argument(
         "--disable_persistent_cache",
-        type=bool,
+        type=str_to_bool,
         help=(
             "Opt into memory-only RPC-result caches. By default the caches "
             "(logs, transactions, receipts, seen) are mirrored to SQLite "
@@ -536,7 +545,7 @@ def initialize_argument_parser() -> ArgumentParser:
 
     parser.add_argument(
         "--clear_cache",
-        type=bool,
+        type=str_to_bool,
         help=(
             "Wipe --cache_dir before startup. One-shot flag; useful for "
             "discarding a stale or corrupted cache without manually "
@@ -559,7 +568,7 @@ def initialize_argument_parser() -> ArgumentParser:
         nargs="?",
         const=1.0,
         default=_get_env_or_default(
-            "VOLTAIRE_CACHE_MEMORY_SIZE", 1.0, float,
+            "VOLTAIRE_CACHE_MEMORY_SIZE", 1.0, positive_float,
         ),
     )
 
@@ -573,7 +582,7 @@ def initialize_argument_parser() -> ArgumentParser:
         nargs="?",
         const=1.0,
         default=_get_env_or_default(
-            "VOLTAIRE_CACHE_DISK_SIZE", 1.0, float,
+            "VOLTAIRE_CACHE_DISK_SIZE", 1.0, positive_float,
         ),
     )
 
@@ -661,7 +670,7 @@ def initialize_argument_parser() -> ArgumentParser:
 
     parser.add_argument(
         "--eip7702",
-        type=bool,
+        type=str_to_bool,
         help="enable eip7702 auth",
         nargs="?",
         const=True,
@@ -670,7 +679,7 @@ def initialize_argument_parser() -> ArgumentParser:
 
     parser.add_argument(
         "--disable_entrypoints_code_check",
-        type=bool,
+        type=str_to_bool,
         help="disable checking if the supported entrypoints are deployed.",
         nargs="?",
         const=True,

--- a/voltaire_bundler/cli_manager.py
+++ b/voltaire_bundler/cli_manager.py
@@ -95,6 +95,10 @@ class InitData:
     # When True, the cache_dir is wiped at startup. One-shot flag for
     # discarding a corrupted or stale cache.
     clear_cache: bool
+    # Per-deployment scale knobs for the cache caps. 1.0 keeps the
+    # built-in defaults; bump up on hosts with more RAM/disk headroom.
+    cache_memory_size: float
+    cache_disk_size: float
 
 
 def address(ep: str):
@@ -117,6 +121,13 @@ def float_at_least_one(value):
     if fvalue < 1.0:
         raise ArgumentTypeError(
                 "%s must be >= 1.0 (shrinking the gas estimate is unsafe)" % value)
+    return fvalue
+
+
+def positive_float(value):
+    fvalue = float(value)
+    if fvalue <= 0:
+        raise ArgumentTypeError("%s must be > 0" % value)
     return fvalue
 
 
@@ -535,6 +546,34 @@ def initialize_argument_parser() -> ArgumentParser:
         const=True,
         default=_get_env_or_default(
             "VOLTAIRE_CLEAR_CACHE", False, lambda v: v.lower() == "true",
+        ),
+    )
+
+    parser.add_argument(
+        "--cache_memory_size",
+        type=positive_float,
+        help=(
+            "Multiplier applied to every cache's in-memory capacity. "
+            "1.0 keeps the 10_000-entry default; 2.0 doubles it."
+        ),
+        nargs="?",
+        const=1.0,
+        default=_get_env_or_default(
+            "VOLTAIRE_CACHE_MEMORY_SIZE", 1.0, float,
+        ),
+    )
+
+    parser.add_argument(
+        "--cache_disk_size",
+        type=positive_float,
+        help=(
+            "Multiplier applied to every cache's on-disk capacity. "
+            "1.0 keeps the 500_000-row default."
+        ),
+        nargs="?",
+        const=1.0,
+        default=_get_env_or_default(
+            "VOLTAIRE_CACHE_DISK_SIZE", 1.0, float,
         ),
     )
 
@@ -1040,6 +1079,8 @@ async def get_init_data(args: Namespace) -> InitData:
         args.disable_persistent_cache,
         args.cache_dir,
         args.clear_cache,
+        args.cache_memory_size,
+        args.cache_disk_size,
     )
 
     if args.verbose:

--- a/voltaire_bundler/cli_manager.py
+++ b/voltaire_bundler/cli_manager.py
@@ -87,6 +87,11 @@ class InitData:
     min_stake: int
     min_unstake_delay: int
     bundle_gas_estimation_multiplier: float
+    # RPC-result caches are mirrored to SQLite files under ``cache_dir`` so
+    # they survive bundler restarts. Set ``disable_persistent_cache`` to opt
+    # into memory-only mode.
+    disable_persistent_cache: bool
+    cache_dir: str
 
 
 def address(ep: str):
@@ -484,6 +489,35 @@ def initialize_argument_parser() -> ArgumentParser:
         nargs="?",
         const=True,
         default=_get_env_or_default("VOLTAIRE_DISABLE_P2P", False, lambda v: v.lower() == "true"),
+    )
+
+    parser.add_argument(
+        "--disable_persistent_cache",
+        type=bool,
+        help=(
+            "Opt into memory-only RPC-result caches. By default the caches "
+            "(logs, transactions, receipts, seen) are mirrored to SQLite "
+            "files under --cache_dir so they survive a bundler restart."
+        ),
+        nargs="?",
+        const=True,
+        default=_get_env_or_default(
+            "VOLTAIRE_DISABLE_PERSISTENT_CACHE", False,
+            lambda v: v.lower() == "true",
+        ),
+    )
+
+    parser.add_argument(
+        "--cache_dir",
+        type=str,
+        help=(
+            "Directory holding persistent-cache SQLite files. Defaults to "
+            "~/.voltaire/cache/<chain_id>. Ignored when "
+            "--disable_persistent_cache is set."
+        ),
+        nargs="?",
+        const="",
+        default=_get_env_or_default("VOLTAIRE_CACHE_DIR", "", str),
     )
 
     parser.add_argument(
@@ -984,7 +1018,9 @@ async def get_init_data(args: Namespace) -> InitData:
         args.p2p_canonical_mempool_id_06,
         args.min_stake,
         args.min_unstake_delay,
-        args.bundle_gas_estimation_multiplier
+        args.bundle_gas_estimation_multiplier,
+        args.disable_persistent_cache,
+        args.cache_dir,
     )
 
     if args.verbose:

--- a/voltaire_bundler/cli_manager.py
+++ b/voltaire_bundler/cli_manager.py
@@ -499,10 +499,10 @@ def initialize_argument_parser() -> ArgumentParser:
     parser.add_argument(
         "--disable_p2p",
         type=bool,
-        help="disable p2p",
+        help="disable p2p (on by default; pass VOLTAIRE_DISABLE_P2P=false to opt in)",
         nargs="?",
         const=True,
-        default=_get_env_or_default("VOLTAIRE_DISABLE_P2P", False, lambda v: v.lower() == "true"),
+        default=_get_env_or_default("VOLTAIRE_DISABLE_P2P", True, lambda v: v.lower() == "true"),
     )
 
     parser.add_argument(

--- a/voltaire_bundler/execution_endpoint.py
+++ b/voltaire_bundler/execution_endpoint.py
@@ -38,6 +38,23 @@ from .mempool.reputation_manager import ReputationManager
 
 user_operation_by_hash_cache: dict[str, dict] = {}
 user_operation_receipt_cache: dict[str, dict] = {}
+user_operation_seen_cache: dict[str, dict[str, str]] = {
+    LocalMempoolManagerV6.entrypoint_lowercase: {},
+    LocalMempoolManagerV7.entrypoint_lowercase: {},
+    LocalMempoolManagerV8.entrypoint_lowercase: {},
+    LocalMempoolManagerV9.entrypoint_lowercase: {},
+}
+
+
+def search_user_operation_seen_cache(
+    user_operation_hash: str,
+) -> tuple[str, str] | None:
+    """Return ``(validated_at_block_hex, entrypoint_lowercase)`` if the hash
+    has been seen, else ``None``."""
+    for entrypoint_lowercase, hash_to_block in user_operation_seen_cache.items():
+        if user_operation_hash in hash_to_block:
+            return hash_to_block[user_operation_hash], entrypoint_lowercase
+    return None
 
 
 class ExecutionEndpoint(Endpoint):
@@ -487,6 +504,9 @@ class ExecutionEndpoint(Endpoint):
         (user_operation_hash, verified_at_block_hash, valid_mempools) = (
             await local_mempool.add_user_operation(user_operation)
         )
+        if user_operation.validated_at_block_hex is not None:
+            user_operation_seen_cache[input_entrypoint][user_operation_hash] = user_operation.validated_at_block_hex
+
         if not self.disable_p2p:
             if (input_entrypoint == LocalMempoolManagerV6.entrypoint_lowercase):
                 user_operation_json = user_operation.get_user_operation_json()
@@ -525,48 +545,63 @@ class ExecutionEndpoint(Endpoint):
         if user_operation_hash in user_operation_by_hash_cache:
             return user_operation_by_hash_cache[user_operation_hash]
 
+        search_result = search_user_operation_seen_cache(user_operation_hash)
+        if search_result is not None:
+            cached_block_hex, cached_entrypoint = search_result
+        else:
+            cached_block_hex, cached_entrypoint = None, None
+
         user_operation_by_hash_json_ops = []
-        if (self.local_mempool_manager_v6 is not None and
-                self.user_operation_handler_v6 is not None):
+        if (
+            self.local_mempool_manager_v6 is not None and
+            self.user_operation_handler_v6 is not None and
+            (cached_entrypoint is None or cached_entrypoint == LocalMempoolManagerV6.entrypoint_lowercase)
+        ):
             user_operation_by_hash_json_ops.append(
                 asyncio.create_task(
                     self.user_operation_handler_v6.get_user_operation_by_hash_rpc(
                         user_operation_hash,
                         LocalMempoolManagerV6.entrypoint,
                         self.local_mempool_manager_v6.senders_to_senders_mempools.values(),
+                        cached_block_hex,
+                    )
+                )
+            )
+        if cached_entrypoint is None or cached_entrypoint == LocalMempoolManagerV9.entrypoint_lowercase:
+            user_operation_by_hash_json_ops.append(
+                asyncio.create_task(
+                    self.user_operation_handler_v7v8v9.get_user_operation_by_hash_rpc(
+                        user_operation_hash,
+                        LocalMempoolManagerV9.entrypoint,
+                        self.local_mempool_manager_v9.senders_to_senders_mempools.values(),
+                        cached_block_hex,
                     )
                 )
             )
 
-        user_operation_by_hash_json_ops.append(
-            asyncio.create_task(
-                self.user_operation_handler_v7v8v9.get_user_operation_by_hash_rpc(
-                    user_operation_hash,
-                    LocalMempoolManagerV9.entrypoint,
-                    self.local_mempool_manager_v9.senders_to_senders_mempools.values(),
+        if cached_entrypoint is None or cached_entrypoint == LocalMempoolManagerV8.entrypoint_lowercase:
+            user_operation_by_hash_json_ops.append(
+                asyncio.create_task(
+                    self.user_operation_handler_v7v8v9.get_user_operation_by_hash_rpc(
+                        user_operation_hash,
+                        LocalMempoolManagerV8.entrypoint,
+                        self.local_mempool_manager_v8.senders_to_senders_mempools.values(),
+                        cached_block_hex,
+                    )
                 )
             )
-        )
 
-        user_operation_by_hash_json_ops.append(
-            asyncio.create_task(
-                self.user_operation_handler_v7v8v9.get_user_operation_by_hash_rpc(
-                    user_operation_hash,
-                    LocalMempoolManagerV8.entrypoint,
-                    self.local_mempool_manager_v8.senders_to_senders_mempools.values(),
+        if cached_entrypoint is None or cached_entrypoint == LocalMempoolManagerV7.entrypoint_lowercase:
+            user_operation_by_hash_json_ops.append(
+                asyncio.create_task(
+                    self.user_operation_handler_v7v8v9.get_user_operation_by_hash_rpc(
+                        user_operation_hash,
+                        LocalMempoolManagerV7.entrypoint,
+                        self.local_mempool_manager_v7.senders_to_senders_mempools.values(),
+                        cached_block_hex,
+                    )
                 )
             )
-        )
-
-        user_operation_by_hash_json_ops.append(
-            asyncio.create_task(
-                self.user_operation_handler_v7v8v9.get_user_operation_by_hash_rpc(
-                    user_operation_hash,
-                    LocalMempoolManagerV7.entrypoint,
-                    self.local_mempool_manager_v7.senders_to_senders_mempools.values(),
-                )
-            )
-        )
         done, _ = await asyncio.wait(
             user_operation_by_hash_json_ops,
             return_when=asyncio.FIRST_EXCEPTION
@@ -640,33 +675,49 @@ class ExecutionEndpoint(Endpoint):
         if user_operation_hash in user_operation_receipt_cache:
             return user_operation_receipt_cache[user_operation_hash]
 
+        search_result = search_user_operation_seen_cache(user_operation_hash)
+        if search_result is not None:
+            cached_block_hex, cached_entrypoint = search_result
+        else:
+            cached_block_hex, cached_entrypoint = None, None
+
         user_operation_receipt_info_json_ops = []
-        if self.user_operation_handler_v6 is not None:
+        if (
+            self.user_operation_handler_v6 is not None and
+            (cached_entrypoint is None or cached_entrypoint == LocalMempoolManagerV6.entrypoint_lowercase)
+        ):
             user_operation_receipt_info_json_ops.append(asyncio.create_task(
                     self.user_operation_handler_v6.get_user_operation_receipt_rpc(
                         user_operation_hash,
                         LocalMempoolManagerV6.entrypoint,
+                        cached_block_hex,
                     ))
                 )
 
-        user_operation_receipt_info_json_ops.append(asyncio.create_task(
-            self.user_operation_handler_v7v8v9.get_user_operation_receipt_rpc(
-                user_operation_hash,
-                LocalMempoolManagerV9.entrypoint,
-            ))
-        )
-        user_operation_receipt_info_json_ops.append(asyncio.create_task(
-            self.user_operation_handler_v7v8v9.get_user_operation_receipt_rpc(
-                user_operation_hash,
-                LocalMempoolManagerV8.entrypoint,
-            ))
-        )
-        user_operation_receipt_info_json_ops.append(asyncio.create_task(
-            self.user_operation_handler_v7v8v9.get_user_operation_receipt_rpc(
-                user_operation_hash,
-                LocalMempoolManagerV7.entrypoint,
-            ))
-        )
+        if cached_entrypoint is None or cached_entrypoint == LocalMempoolManagerV9.entrypoint_lowercase:
+            user_operation_receipt_info_json_ops.append(asyncio.create_task(
+                self.user_operation_handler_v7v8v9.get_user_operation_receipt_rpc(
+                    user_operation_hash,
+                    LocalMempoolManagerV9.entrypoint,
+                    cached_block_hex,
+                ))
+            )
+        if cached_entrypoint is None or cached_entrypoint == LocalMempoolManagerV8.entrypoint_lowercase:
+            user_operation_receipt_info_json_ops.append(asyncio.create_task(
+                self.user_operation_handler_v7v8v9.get_user_operation_receipt_rpc(
+                    user_operation_hash,
+                    LocalMempoolManagerV8.entrypoint,
+                    cached_block_hex,
+                ))
+            )
+        if cached_entrypoint is None or cached_entrypoint == LocalMempoolManagerV7.entrypoint_lowercase:
+            user_operation_receipt_info_json_ops.append(asyncio.create_task(
+                self.user_operation_handler_v7v8v9.get_user_operation_receipt_rpc(
+                    user_operation_hash,
+                    LocalMempoolManagerV7.entrypoint,
+                    cached_block_hex,
+                ))
+            )
         done, _ = await asyncio.wait(
             user_operation_receipt_info_json_ops,
             return_when=asyncio.FIRST_EXCEPTION

--- a/voltaire_bundler/execution_endpoint.py
+++ b/voltaire_bundler/execution_endpoint.py
@@ -573,6 +573,16 @@ class ExecutionEndpoint(Endpoint):
         else:
             cached_block_hex, cached_entrypoint = None, None
 
+        # The seen-cache survives restarts, so a hit can point at v0.6
+        # even when this process started with --disable_v6. Drop the hint
+        # in that case so we still fan out to the enabled handlers instead
+        # of building an empty task set (which would crash asyncio.wait).
+        if (
+            cached_entrypoint == LocalMempoolManagerV6.entrypoint_lowercase
+            and self.user_operation_handler_v6 is None
+        ):
+            cached_entrypoint = None
+
         user_operation_by_hash_json_ops = []
         if (
             self.local_mempool_manager_v6 is not None and
@@ -702,6 +712,15 @@ class ExecutionEndpoint(Endpoint):
             cached_block_hex, cached_entrypoint = search_result
         else:
             cached_block_hex, cached_entrypoint = None, None
+
+        # See _event_rpc_getUserOperationByHash: ignore a cached v0.6 hint
+        # when v6 is disabled in this process so we don't end up with an
+        # empty task set.
+        if (
+            cached_entrypoint == LocalMempoolManagerV6.entrypoint_lowercase
+            and self.user_operation_handler_v6 is None
+        ):
+            cached_entrypoint = None
 
         user_operation_receipt_info_json_ops = []
         if (

--- a/voltaire_bundler/execution_endpoint.py
+++ b/voltaire_bundler/execution_endpoint.py
@@ -58,14 +58,21 @@ async def search_user_operation_seen_cache(
     user_operation_hash: str,
 ) -> tuple[str, str] | None:
     """Return ``(validated_at_block_hex, entrypoint_lowercase)`` if the hash
-    has been seen, else ``None``. Async because ``get`` may fall through to
-    the on-disk tier."""
+    has been seen, else ``None``. One bulk lookup covers all four entrypoint
+    versions: memory hits short-circuit at the dict level, and any keys that
+    miss memory go to disk in a single ``SELECT … WHERE key IN (…)`` instead
+    of four sequential round trips."""
+    keys = [
+        f"{ep}:{user_operation_hash}" for ep in _SEEN_CACHE_ENTRYPOINTS
+    ]
+    found = await user_operation_seen_cache.get_many(keys)
+    # Re-walk in entrypoint priority order so we return the same answer as
+    # the previous one-at-a-time loop if a hash somehow lives under more
+    # than one entrypoint key.
     for entrypoint_lowercase in _SEEN_CACHE_ENTRYPOINTS:
-        value = await user_operation_seen_cache.get(
-            f"{entrypoint_lowercase}:{user_operation_hash}"
-        )
-        if value is not None:
-            return value, entrypoint_lowercase
+        key = f"{entrypoint_lowercase}:{user_operation_hash}"
+        if key in found:
+            return found[key], entrypoint_lowercase
     return None
 
 

--- a/voltaire_bundler/execution_endpoint.py
+++ b/voltaire_bundler/execution_endpoint.py
@@ -27,6 +27,7 @@ from voltaire_bundler.user_operation.user_operation_handler_v7v8v9 import \
     UserOperationHandlerV7V8V9
 from voltaire_bundler.user_operation.user_operation_handler import \
     fell_user_operation_optional_parameters_for_estimateUserOperationGas
+from voltaire_bundler.utils.cache import InMemoryFIFOCache
 from voltaire_bundler.utils.eth_client_utils import get_block_info, send_rpc_request_to_eth_client
 
 from .bundle.bundle_manager import BundlerManager
@@ -38,12 +39,19 @@ from .mempool.reputation_manager import ReputationManager
 
 user_operation_by_hash_cache: dict[str, dict] = {}
 user_operation_receipt_cache: dict[str, dict] = {}
-user_operation_seen_cache: dict[str, dict[str, str]] = {
-    LocalMempoolManagerV6.entrypoint_lowercase: {},
-    LocalMempoolManagerV7.entrypoint_lowercase: {},
-    LocalMempoolManagerV8.entrypoint_lowercase: {},
-    LocalMempoolManagerV9.entrypoint_lowercase: {},
-}
+
+# Composite-key cache: "{entrypoint_lowercase}:{userOpHash}" -> validated_at_block_hex.
+# Flattening the previous per-entrypoint nested dict keeps the new InMemoryFIFOCache
+# interface uniform across all four caches and prepares for the on-disk tier
+# (one SQLite row per entry, composite primary key).
+user_operation_seen_cache = InMemoryFIFOCache(name="user_operation_seen")
+
+_SEEN_CACHE_ENTRYPOINTS = (
+    LocalMempoolManagerV6.entrypoint_lowercase,
+    LocalMempoolManagerV7.entrypoint_lowercase,
+    LocalMempoolManagerV8.entrypoint_lowercase,
+    LocalMempoolManagerV9.entrypoint_lowercase,
+)
 
 
 def search_user_operation_seen_cache(
@@ -51,9 +59,12 @@ def search_user_operation_seen_cache(
 ) -> tuple[str, str] | None:
     """Return ``(validated_at_block_hex, entrypoint_lowercase)`` if the hash
     has been seen, else ``None``."""
-    for entrypoint_lowercase, hash_to_block in user_operation_seen_cache.items():
-        if user_operation_hash in hash_to_block:
-            return hash_to_block[user_operation_hash], entrypoint_lowercase
+    for entrypoint_lowercase in _SEEN_CACHE_ENTRYPOINTS:
+        value = user_operation_seen_cache.get(
+            f"{entrypoint_lowercase}:{user_operation_hash}"
+        )
+        if value is not None:
+            return value, entrypoint_lowercase
     return None
 
 
@@ -505,7 +516,10 @@ class ExecutionEndpoint(Endpoint):
             await local_mempool.add_user_operation(user_operation)
         )
         if user_operation.validated_at_block_hex is not None:
-            user_operation_seen_cache[input_entrypoint][user_operation_hash] = user_operation.validated_at_block_hex
+            user_operation_seen_cache.set(
+                f"{input_entrypoint}:{user_operation_hash}",
+                user_operation.validated_at_block_hex,
+            )
 
         if not self.disable_p2p:
             if (input_entrypoint == LocalMempoolManagerV6.entrypoint_lowercase):

--- a/voltaire_bundler/execution_endpoint.py
+++ b/voltaire_bundler/execution_endpoint.py
@@ -27,7 +27,7 @@ from voltaire_bundler.user_operation.user_operation_handler_v7v8v9 import \
     UserOperationHandlerV7V8V9
 from voltaire_bundler.user_operation.user_operation_handler import \
     fell_user_operation_optional_parameters_for_estimateUserOperationGas
-from voltaire_bundler.utils.cache import InMemoryFIFOCache
+from voltaire_bundler.utils.cache import PersistentFIFOCache
 from voltaire_bundler.utils.eth_client_utils import get_block_info, send_rpc_request_to_eth_client
 
 from .bundle.bundle_manager import BundlerManager
@@ -41,10 +41,10 @@ user_operation_by_hash_cache: dict[str, dict] = {}
 user_operation_receipt_cache: dict[str, dict] = {}
 
 # Composite-key cache: "{entrypoint_lowercase}:{userOpHash}" -> validated_at_block_hex.
-# Flattening the previous per-entrypoint nested dict keeps the new InMemoryFIFOCache
-# interface uniform across all four caches and prepares for the on-disk tier
-# (one SQLite row per entry, composite primary key).
-user_operation_seen_cache = InMemoryFIFOCache(name="user_operation_seen")
+# Flattening the previous per-entrypoint nested dict keeps the cache interface
+# uniform across all four caches; the on-disk tier stores one row per entry
+# with the composite primary key.
+user_operation_seen_cache = PersistentFIFOCache(name="user_operation_seen")
 
 _SEEN_CACHE_ENTRYPOINTS = (
     LocalMempoolManagerV6.entrypoint_lowercase,
@@ -54,13 +54,14 @@ _SEEN_CACHE_ENTRYPOINTS = (
 )
 
 
-def search_user_operation_seen_cache(
+async def search_user_operation_seen_cache(
     user_operation_hash: str,
 ) -> tuple[str, str] | None:
     """Return ``(validated_at_block_hex, entrypoint_lowercase)`` if the hash
-    has been seen, else ``None``."""
+    has been seen, else ``None``. Async because ``get`` may fall through to
+    the on-disk tier."""
     for entrypoint_lowercase in _SEEN_CACHE_ENTRYPOINTS:
-        value = user_operation_seen_cache.get(
+        value = await user_operation_seen_cache.get(
             f"{entrypoint_lowercase}:{user_operation_hash}"
         )
         if value is not None:
@@ -559,7 +560,7 @@ class ExecutionEndpoint(Endpoint):
         if user_operation_hash in user_operation_by_hash_cache:
             return user_operation_by_hash_cache[user_operation_hash]
 
-        search_result = search_user_operation_seen_cache(user_operation_hash)
+        search_result = await search_user_operation_seen_cache(user_operation_hash)
         if search_result is not None:
             cached_block_hex, cached_entrypoint = search_result
         else:
@@ -689,7 +690,7 @@ class ExecutionEndpoint(Endpoint):
         if user_operation_hash in user_operation_receipt_cache:
             return user_operation_receipt_cache[user_operation_hash]
 
-        search_result = search_user_operation_seen_cache(user_operation_hash)
+        search_result = await search_user_operation_seen_cache(user_operation_hash)
         if search_result is not None:
             cached_block_hex, cached_entrypoint = search_result
         else:

--- a/voltaire_bundler/main.py
+++ b/voltaire_bundler/main.py
@@ -3,6 +3,7 @@ import logging
 import os
 import sys
 from functools import partial
+from pathlib import Path
 from signal import SIGINT, SIGTERM
 import platform
 if platform.system() != "Windows":
@@ -12,6 +13,7 @@ from voltaire_bundler.mempool.mempool_info import DEFAULT_MEMPOOL_INFO
 from voltaire_bundler.metrics.metrics import run_metrics_server
 from voltaire_bundler.p2p_boot import p2p_boot
 from voltaire_bundler.rpc.health import periodic_health_check_cron_job
+from voltaire_bundler.utils.cache import PersistentFIFOCache
 from voltaire_bundler.utils.SignalHaltError import immediate_exit
 
 from .cli_manager import parse_args
@@ -55,6 +57,19 @@ async def main(cmd_args=sys.argv[1:], loop=None) -> None:
             )
             loop.add_signal_handler(signal_enum, exit_func)
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
+    # Start the RPC-result caches. By default each cache opens a SQLite file
+    # under cache_dir and resumes from any prior state;
+    # --disable_persistent_cache opts into in-memory-only mode.
+    if init_data.disable_persistent_cache:
+        await PersistentFIFOCache.start_all(cache_dir=None)
+    else:
+        cache_dir = (
+            Path(init_data.cache_dir).expanduser()
+            if init_data.cache_dir
+            else Path.home() / ".voltaire" / "cache" / str(init_data.chain_id)
+        )
+        await PersistentFIFOCache.start_all(cache_dir=cache_dir)
 
     try:
         async with asyncio.TaskGroup() as task_group:
@@ -129,3 +144,8 @@ async def main(cmd_args=sys.argv[1:], loop=None) -> None:
                     logging.exception(str(excp))
     except asyncio.exceptions.CancelledError:
         pass
+    finally:
+        # Drain queued disk writes and close SQLite handles. Bounded by the
+        # write-queue size (~10k) × per-batch latency; typically well under a
+        # second.
+        await PersistentFIFOCache.aclose_all()

--- a/voltaire_bundler/main.py
+++ b/voltaire_bundler/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import shutil
 import sys
 from functools import partial
 from pathlib import Path
@@ -69,6 +70,9 @@ async def main(cmd_args=sys.argv[1:], loop=None) -> None:
             if init_data.cache_dir
             else Path.home() / ".voltaire" / "cache" / str(init_data.chain_id)
         )
+        if init_data.clear_cache and cache_dir.exists():
+            logging.info("clearing persistent cache at %s", cache_dir)
+            shutil.rmtree(cache_dir)
         await PersistentFIFOCache.start_all(cache_dir=cache_dir)
 
     try:

--- a/voltaire_bundler/main.py
+++ b/voltaire_bundler/main.py
@@ -156,7 +156,15 @@ async def main(cmd_args=sys.argv[1:], loop=None) -> None:
     except asyncio.exceptions.CancelledError:
         pass
     finally:
-        # Drain queued disk writes and close SQLite handles. Bounded by the
-        # write-queue size (~10k) × per-batch latency; typically well under a
-        # second.
+        # Drain queued disk writes and close SQLite handles cleanly. This only
+        # actually runs on a programmatic TaskGroup exit — the SIGTERM/SIGINT
+        # path goes through ``immediate_exit`` which stops the loop and raises
+        # SystemExit, so this ``await`` never resumes on a real shutdown.
+        #
+        # That's deliberate. The cached values are derived from chain state, so
+        # losing the asyncio.Queue's tail (typically <1 ms of writes, at most a
+        # few hundred ms under burst) just means a small cache-warm window on
+        # the next start. A synchronous drain on SIGTERM would add up to a few
+        # seconds of "RPC server frozen + new connections rejected" before exit
+        # for marginal durability gain, so we accept the loss instead.
         await PersistentFIFOCache.aclose_all()

--- a/voltaire_bundler/main.py
+++ b/voltaire_bundler/main.py
@@ -59,6 +59,13 @@ async def main(cmd_args=sys.argv[1:], loop=None) -> None:
             loop.add_signal_handler(signal_enum, exit_func)
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
+    # Apply the size multipliers BEFORE start_all so warm-on-start observes
+    # the scaled memory cap.
+    PersistentFIFOCache.apply_capacity_multipliers(
+        memory_mult=init_data.cache_memory_size,
+        disk_mult=init_data.cache_disk_size,
+    )
+
     # Start the RPC-result caches. By default each cache opens a SQLite file
     # under cache_dir and resumes from any prior state;
     # --disable_persistent_cache opts into in-memory-only mode.

--- a/voltaire_bundler/main.py
+++ b/voltaire_bundler/main.py
@@ -82,6 +82,10 @@ async def main(cmd_args=sys.argv[1:], loop=None) -> None:
             shutil.rmtree(cache_dir)
         await PersistentFIFOCache.start_all(cache_dir=cache_dir)
 
+    # Synchronous part is free; the follow-up disk-row totals run in a
+    # background task so the COUNT(*) work doesn't extend startup.
+    PersistentFIFOCache.log_startup_status()
+
     try:
         async with asyncio.TaskGroup() as task_group:
             execution_endpoint: ExecutionEndpoint = ExecutionEndpoint(

--- a/voltaire_bundler/user_operation/user_operation_handler.py
+++ b/voltaire_bundler/user_operation/user_operation_handler.py
@@ -604,6 +604,17 @@ async def get_user_operation_logs_for_block_range(
 transactions_cache = PersistentFIFOCache(name="transactions")
 
 
+# Only the fields the two callers (``get_user_operation_by_hash`` in v6 and
+# v7v8v9) actually read. Trimming the rest (gas/gasPrice/v/r/s/accessList/
+# nonce/value/chainId/etc.) keeps disk + RAM footprint down without losing
+# anything we'd ever use.
+TRANSACTION_CACHED_FIELDS = (
+    "blockHash",
+    "blockNumber",
+    "input",
+)
+
+
 TRANSACTION_RECEIPT_CACHED_FIELDS = (
     "blockHash",
     "blockNumber",
@@ -675,6 +686,15 @@ async def get_transaction_by_hash(
                 ethereum_node_urls, transaction_hash, recursion_depth
             )
         else:
+            # Trim to the fields the caller actually reads before caching.
+            # Subsequent cache hits return this same shape; the in-flight
+            # caller below also gets the trimmed dict so cache-hit vs.
+            # cache-miss paths return identical objects.
+            transaction = {
+                field: transaction[field]
+                for field in TRANSACTION_CACHED_FIELDS
+                if field in transaction
+            }
             transactions_cache.set(transaction_hash, transaction)
         return transaction
     else:

--- a/voltaire_bundler/user_operation/user_operation_handler.py
+++ b/voltaire_bundler/user_operation/user_operation_handler.py
@@ -345,8 +345,12 @@ class UserOperationHandler(ABC):
 
             if earliest_block_number < 0:
                 earliest_block_number = 0
+            # range stop is exclusive; bumping by 1 makes the final iteration
+            # include latest_block_number, which is otherwise dropped when
+            # validated_at_block_hex == latest (a common poll-just-after-
+            # inclusion case where the head block would yield no eth_getLogs).
             for earliest_block in range(earliest_block_number,
-                                        latest_block_number,
+                                        latest_block_number + 1,
                                         logs_incremental_range):
                 latest_block = earliest_block + logs_incremental_range
                 if latest_block <= earliest_block:

--- a/voltaire_bundler/user_operation/user_operation_handler.py
+++ b/voltaire_bundler/user_operation/user_operation_handler.py
@@ -9,6 +9,7 @@ from eth_abi import encode, decode
 from voltaire_bundler.bundle.exceptions import UserOpReceiptFoundException
 from voltaire_bundler.mempool.sender_mempool import VerifiedUserOperation
 from voltaire_bundler.custom_types import Address
+from voltaire_bundler.utils.cache import InMemoryFIFOCache
 from voltaire_bundler.utils.eth_client_utils import \
         get_block_info, send_rpc_request_to_eth_client
 from typing import Any
@@ -106,13 +107,7 @@ class UserOperationHandler(ABC):
         transaction = await self.get_transaction_receipt(
                 log_object.transactionHash)
 
-        if (  # pending log
-            transaction is None or
-            "blockNumber" not in transaction or transaction["blockNumber"] is None or
-            "transactionHash" not in transaction or transaction["transactionHash"] is None or
-            "transactionIndex" not in transaction or transaction["transactionIndex"] is None or
-            "blockHash" not in transaction
-        ):
+        if transaction is None:  # pending — caller will retry
             return None
 
         if "effectiveGasPrice" in transaction:
@@ -254,13 +249,35 @@ class UserOperationHandler(ABC):
             logs,
         )
 
-    async def get_transaction_receipt(self, transaction_hash: str) -> dict:
+    async def get_transaction_receipt(
+        self, transaction_hash: str
+    ) -> dict | None:
+        cached = transaction_receipts_cache.get(transaction_hash)
+        if cached is not None:
+            return cached
+
         params = [transaction_hash]
         res: Any = await send_rpc_request_to_eth_client(
             self.ethereum_node_urls, "eth_getTransactionReceipt", params,
             None, "result"
         )
-        return res["result"]
+        transaction = res["result"]
+        if (  # pending or missing receipt — don't cache, let the caller retry
+            transaction is None or
+            transaction.get("blockNumber") is None or
+            transaction.get("transactionHash") is None or
+            transaction.get("transactionIndex") is None or
+            "blockHash" not in transaction
+        ):
+            return None
+
+        trimmed = {
+            field: transaction[field]
+            for field in TRANSACTION_RECEIPT_CACHED_FIELDS
+            if field in transaction
+        }
+        transaction_receipts_cache.set(transaction_hash, trimmed)
+        return trimmed
 
     async def get_user_operation_logs(
         self,
@@ -403,22 +420,19 @@ async def get_deposit_info(
         else:
             raise ValueError("balanceOf eth_call failed")
 
-user_operation_logs_cache: dict[str, dict[str, dict]] = {
-    "0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789": {},
-    "0x0000000071727de22e5e9d8baf0edac6f37da032": {},
-    "0x4337084d9e255ff0702461cf8895ce9e3b5ff108": {},
-    "0x433709009b8330fda32311df1c2afa402ed8d009": {},
-}
+# Composite-key cache: "{entrypoint_lowercase}:{userOpHash}" -> eth_getLogs result.
+# Flattens the previous per-entrypoint nested dict (which also had a broken
+# eviction path: ``logs_cache = {}`` rebound a local, never the outer dict).
+user_operation_logs_cache = InMemoryFIFOCache(name="user_operation_logs")
 
 
 def del_user_operation_logs_cache_entry(
     user_operation_hash: str,
     entrypoint: str,
 ) -> None:
-    global user_operation_logs_cache
-    logs_cache = user_operation_logs_cache[entrypoint.lower()]
-    if user_operation_hash in logs_cache:
-        del logs_cache[user_operation_hash]
+    user_operation_logs_cache.delete(
+        f"{entrypoint.lower()}:{user_operation_hash}"
+    )
 
 
 async def get_user_operation_logs_for_block_range(
@@ -428,10 +442,10 @@ async def get_user_operation_logs_for_block_range(
     from_block_hex: str,
     to_block_hex: str,
 ) -> dict | None:
-    global user_operation_logs_cache
-    logs_cache = user_operation_logs_cache[entrypoint.lower()]
-    if user_operation_hash in logs_cache:
-        return logs_cache[user_operation_hash]
+    cache_key = f"{entrypoint.lower()}:{user_operation_hash}"
+    cached = user_operation_logs_cache.get(cache_key)
+    if cached is not None:
+        return cached
     USER_OPERATIOM_EVENT_DISCRIPTOR = (
         "0x49628fd1471006c1482da88028e9ce4dbb080b815c9b0344d39e5a8e6ec1419f"
     )
@@ -451,16 +465,32 @@ async def get_user_operation_logs_for_block_range(
         ethereum_node_eth_get_logs_urls, "eth_getLogs", params
     )
     if "result" in res and len(res["result"]) > 0:
-        # clear cache if bigger than 10_000
-        if len(logs_cache) > 10_000:
-            logs_cache = {}
-        logs_cache[user_operation_hash] = res['result']
+        user_operation_logs_cache.set(cache_key, res['result'])
         return res['result']
     else:
         return None
 
 
-transactions_cache: dict[str, dict] = {}
+transactions_cache = InMemoryFIFOCache(name="transactions")
+
+
+TRANSACTION_RECEIPT_CACHED_FIELDS = (
+    "blockHash",
+    "blockNumber",
+    "transactionHash",
+    "transactionIndex",
+    "from",
+    "to",
+    "cumulativeGasUsed",
+    "gasUsed",
+    "contractAddress",
+    "logs",
+    "logsBloom",
+    "status",
+    "effectiveGasPrice",
+)
+
+transaction_receipts_cache = InMemoryFIFOCache(name="transaction_receipts")
 
 
 async def get_transaction_by_hash(
@@ -474,9 +504,9 @@ async def get_transaction_by_hash(
         logging.error("get_transaction_by_hash recursion too deep.")
         return None
 
-    global transactions_cache
-    if transaction_hash in transactions_cache:
-        return transactions_cache[transaction_hash]
+    cached = transactions_cache.get(transaction_hash)
+    if cached is not None:
+        return cached
     params = [transaction_hash]
     res: Any = await send_rpc_request_to_eth_client(
         ethereum_node_urls, "eth_getTransactionByHash", params
@@ -495,10 +525,7 @@ async def get_transaction_by_hash(
                 ethereum_node_urls, transaction_hash, recursion_depth
             )
         else:
-            # clear cache if bigger than 10_000
-            if len(transactions_cache) > 10_000:
-                transactions_cache = {}
-            transactions_cache[transaction_hash] = transaction
+            transactions_cache.set(transaction_hash, transaction)
         return transaction
     else:
         if "error" in res:

--- a/voltaire_bundler/user_operation/user_operation_handler.py
+++ b/voltaire_bundler/user_operation/user_operation_handler.py
@@ -343,8 +343,16 @@ class UserOperationHandler(ABC):
                 else:
                     earliest_block_number = validated_at_block_number
 
-            if earliest_block_number < 0:
-                earliest_block_number = 0
+            # Clamp into [0, latest_block_number]. Upper-clamp guards
+            # against the validation RPC being ahead of the logs RPC
+            # (e.g. multi-node setup where the logs endpoint is
+            # mid-sync) — without it, validated > latest would produce
+            # an empty range() below and we'd return None without
+            # making a single eth_getLogs call, even though the logs
+            # node may catch up in the next millisecond.
+            earliest_block_number = max(
+                0, min(earliest_block_number, latest_block_number),
+            )
             # range stop is exclusive; bumping by 1 makes the final iteration
             # include latest_block_number, which is otherwise dropped when
             # validated_at_block_hex == latest (a common poll-just-after-

--- a/voltaire_bundler/user_operation/user_operation_handler.py
+++ b/voltaire_bundler/user_operation/user_operation_handler.py
@@ -452,6 +452,10 @@ user_operation_logs_cache = PersistentFIFOCache(name="user_operation_logs")
 # per-attempt aiohttp timeout, which can stretch a single lookup into
 # minutes on a slow or misbehaving node. Capping here means a hash lookup
 # degrades to "miss" quickly instead of stalling the RPC handler.
+#
+# Operators on a slow or remote RPC provider that legitimately needs more
+# than 2 s per call: bump this constant. It isn't surfaced as a CLI/env
+# knob yet; promote it if more than one deployment ends up patching it.
 ETH_RPC_LOOKUP_TIMEOUT_S = 2.0
 
 # When the caller asks for ``fromBlock="earliest"``, try a narrower recent

--- a/voltaire_bundler/user_operation/user_operation_handler.py
+++ b/voltaire_bundler/user_operation/user_operation_handler.py
@@ -552,6 +552,63 @@ async def _eth_getLogs_once(
         return None
 
 
+async def _cached_logs_block_still_canonical(
+    ethereum_node_urls: list[str],
+    cached_logs: list,
+) -> bool:
+    """Confirm the cached log set's block is still on the canonical chain.
+
+    The userop-logs cache is keyed by ``entrypoint:userOpHash``. After a
+    reorg the same userop hash can land in a different block, but a hit
+    in the cache would otherwise return the orphaned block's logs forever
+    (the cache key never changes). One ``eth_getBlockByNumber`` per cache
+    hit is cheap relative to the eth_getLogs scan it shields, and
+    eth_getBlockByNumber always returns the canonical block at that
+    height — so a hash mismatch is a definitive reorg signal.
+
+    Returns False on reorg, on the block disappearing, on a malformed
+    cached payload, and on any RPC failure (so the caller drops the
+    entry and re-fetches rather than serving stale data)."""
+    if not cached_logs:
+        return False
+    first = cached_logs[0]
+    if not isinstance(first, dict):
+        return False
+    block_hash = first.get("blockHash")
+    block_number = first.get("blockNumber")
+    if not isinstance(block_hash, str) or not isinstance(block_number, str):
+        return False
+    try:
+        res = await asyncio.wait_for(
+            send_rpc_request_to_eth_client(
+                ethereum_node_urls,
+                "eth_getBlockByNumber",
+                [block_number, False],
+            ),
+            timeout=ETH_RPC_LOOKUP_TIMEOUT_S,
+        )
+    except asyncio.TimeoutError:
+        logging.warning(
+            "eth_getBlockByNumber(%s) timed out during reorg revalidation; "
+            "treating cached userop-logs entry as stale",
+            block_number,
+        )
+        return False
+    except Exception:
+        logging.warning(
+            "eth_getBlockByNumber(%s) failed during reorg revalidation; "
+            "treating cached userop-logs entry as stale",
+            block_number, exc_info=True,
+        )
+        return False
+    if not isinstance(res, dict):
+        return False
+    result = res.get("result")
+    if not isinstance(result, dict):
+        return False
+    return result.get("hash") == block_hash
+
+
 async def _fetch_latest_block_number(
     ethereum_node_urls: list[str],
 ) -> int | None:
@@ -590,7 +647,14 @@ async def get_user_operation_logs_for_block_range(
     cache_key = f"{entrypoint.lower()}:{user_operation_hash}"
     cached = await user_operation_logs_cache.get(cache_key)
     if cached is not None:
-        return cached
+        if await _cached_logs_block_still_canonical(
+            ethereum_node_eth_get_logs_urls, cached,
+        ):
+            return cached
+        # Cached block was reorged out (or revalidation failed). Drop the
+        # entry so we don't keep serving stale data, then fall through to
+        # the fresh eth_getLogs path below.
+        user_operation_logs_cache.delete(cache_key)
 
     # If the caller asked for the whole chain, first probe the last
     # EARLIEST_FALLBACK_RECENT_WINDOW blocks — that covers the typical

--- a/voltaire_bundler/user_operation/user_operation_handler.py
+++ b/voltaire_bundler/user_operation/user_operation_handler.py
@@ -257,27 +257,49 @@ class UserOperationHandler(ABC):
             return cached
 
         params = [transaction_hash]
-        res: Any = await send_rpc_request_to_eth_client(
-            self.ethereum_node_urls, "eth_getTransactionReceipt", params,
-            None, "result"
-        )
-        transaction = res["result"]
-        if (  # pending or missing receipt — don't cache, let the caller retry
-            transaction is None or
-            transaction.get("blockNumber") is None or
-            transaction.get("transactionHash") is None or
-            transaction.get("transactionIndex") is None or
-            "blockHash" not in transaction
-        ):
-            return None
+        # Same safety net as eth_getLogs: cap wall time and swallow every
+        # error mode (timeout, network error, non-standard response shape,
+        # RPC-level error after retries). A missed receipt is just a "not
+        # yet confirmed" signal to the caller; nothing here should bubble
+        # up and fail the RPC handler.
+        try:
+            res = await asyncio.wait_for(
+                send_rpc_request_to_eth_client(
+                    self.ethereum_node_urls, "eth_getTransactionReceipt",
+                    params, None, "result",
+                ),
+                timeout=ETH_RPC_LOOKUP_TIMEOUT_S,
+            )
+            transaction = res["result"]
+            if (  # pending or missing receipt — don't cache, let the caller retry
+                transaction is None or
+                transaction.get("blockNumber") is None or
+                transaction.get("transactionHash") is None or
+                transaction.get("transactionIndex") is None or
+                "blockHash" not in transaction
+            ):
+                return None
 
-        trimmed = {
-            field: transaction[field]
-            for field in TRANSACTION_RECEIPT_CACHED_FIELDS
-            if field in transaction
-        }
-        transaction_receipts_cache.set(transaction_hash, trimmed)
-        return trimmed
+            trimmed = {
+                field: transaction[field]
+                for field in TRANSACTION_RECEIPT_CACHED_FIELDS
+                if field in transaction
+            }
+            transaction_receipts_cache.set(transaction_hash, trimmed)
+            return trimmed
+        except asyncio.TimeoutError:
+            logging.error(
+                "eth_getTransactionReceipt(%s) timed out after %ss; "
+                "treating as miss",
+                transaction_hash, ETH_RPC_LOOKUP_TIMEOUT_S,
+            )
+            return None
+        except Exception:
+            logging.error(
+                "eth_getTransactionReceipt(%s) failed; treating as miss",
+                transaction_hash, exc_info=True,
+            )
+            return None
 
     async def get_user_operation_logs(
         self,
@@ -425,6 +447,21 @@ async def get_deposit_info(
 # eviction path: ``logs_cache = {}`` rebound a local, never the outer dict).
 user_operation_logs_cache = PersistentFIFOCache(name="user_operation_logs")
 
+# Wall-clock budget for a single RPC lookup against an Ethereum node
+# (eth_getLogs / eth_getTransactionReceipt / eth_getTransactionByHash).
+# The shared RPC helper retries up to 60× with 1 s sleeps and a 60 s
+# per-attempt aiohttp timeout, which can stretch a single lookup into
+# minutes on a slow or misbehaving node. Capping here means a hash lookup
+# degrades to "miss" quickly instead of stalling the RPC handler.
+ETH_RPC_LOOKUP_TIMEOUT_S = 2.0
+
+# When the caller asks for ``fromBlock="earliest"``, try a narrower recent
+# window first. The vast majority of getUserOperationByHash/Receipt calls
+# are clients polling a userop submitted seconds ago, which lives well
+# within this window — and many nodes either time out or return invalid
+# responses for a full-history eth_getLogs scan.
+EARLIEST_FALLBACK_RECENT_WINDOW = 5_000
+
 
 def del_user_operation_logs_cache_entry(
     user_operation_hash: str,
@@ -435,40 +472,133 @@ def del_user_operation_logs_cache_entry(
     )
 
 
-async def get_user_operation_logs_for_block_range(
+USER_OPERATION_EVENT_DESCRIPTOR = (
+    "0x49628fd1471006c1482da88028e9ce4dbb080b815c9b0344d39e5a8e6ec1419f"
+)
+
+
+async def _eth_getLogs_once(
     ethereum_node_eth_get_logs_urls: list[str],
     user_operation_hash: str,
     entrypoint: str,
     from_block_hex: str,
     to_block_hex: str,
-) -> dict | None:
-    cache_key = f"{entrypoint.lower()}:{user_operation_hash}"
-    cached = await user_operation_logs_cache.get(cache_key)
-    if cached is not None:
-        return cached
-    USER_OPERATIOM_EVENT_DISCRIPTOR = (
-        "0x49628fd1471006c1482da88028e9ce4dbb080b815c9b0344d39e5a8e6ec1419f"
-    )
-
+) -> list | None:
+    """Single eth_getLogs round trip with timeout + broad safety.
+    Returns the logs list on a non-empty hit, ``None`` on miss or any failure
+    (timeout, network error, non-standard response shape, RPC-level error
+    after retries). Nothing here bubbles up — the caller decides whether to
+    retry with a different range or fall through to "not found"."""
     params = [
         {
             "address": entrypoint,
             "topics": [
-                USER_OPERATIOM_EVENT_DISCRIPTOR,
+                USER_OPERATION_EVENT_DESCRIPTOR,
                 user_operation_hash,
             ],
             "fromBlock": from_block_hex,
             "toBlock": to_block_hex,
         }
     ]
-    res = await send_rpc_request_to_eth_client(
-        ethereum_node_eth_get_logs_urls, "eth_getLogs", params
-    )
-    if "result" in res and len(res["result"]) > 0:
-        user_operation_logs_cache.set(cache_key, res['result'])
-        return res['result']
-    else:
+    try:
+        res = await asyncio.wait_for(
+            send_rpc_request_to_eth_client(
+                ethereum_node_eth_get_logs_urls, "eth_getLogs", params,
+            ),
+            timeout=ETH_RPC_LOOKUP_TIMEOUT_S,
+        )
+        if (
+            isinstance(res, dict)
+            and isinstance(res.get("result"), list)
+            and len(res["result"]) > 0
+        ):
+            return res["result"]
         return None
+    except asyncio.TimeoutError:
+        logging.error(
+            "eth_getLogs (%s -> %s) timed out after %ss; treating as miss",
+            from_block_hex, to_block_hex, ETH_RPC_LOOKUP_TIMEOUT_S,
+        )
+        return None
+    except Exception:
+        logging.error(
+            "eth_getLogs (%s -> %s) failed; treating as miss",
+            from_block_hex, to_block_hex, exc_info=True,
+        )
+        return None
+
+
+async def _fetch_latest_block_number(
+    ethereum_node_urls: list[str],
+) -> int | None:
+    """Return the latest block number as int, or ``None`` on any failure.
+    Same 2 s budget + total exception safety as the eth_getLogs path; used
+    to size the recent-window fallback below."""
+    try:
+        block_info = await asyncio.wait_for(
+            get_block_info(ethereum_node_urls),
+            timeout=ETH_RPC_LOOKUP_TIMEOUT_S,
+        )
+        return int(block_info[0], 16)
+    except asyncio.TimeoutError:
+        logging.error(
+            "eth_getBlockByNumber(latest) timed out after %ss; "
+            "skipping recent-window fallback",
+            ETH_RPC_LOOKUP_TIMEOUT_S,
+        )
+        return None
+    except Exception:
+        logging.error(
+            "eth_getBlockByNumber(latest) failed; "
+            "skipping recent-window fallback",
+            exc_info=True,
+        )
+        return None
+
+
+async def get_user_operation_logs_for_block_range(
+    ethereum_node_eth_get_logs_urls: list[str],
+    user_operation_hash: str,
+    entrypoint: str,
+    from_block_hex: str,
+    to_block_hex: str,
+) -> list | None:
+    cache_key = f"{entrypoint.lower()}:{user_operation_hash}"
+    cached = await user_operation_logs_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    # If the caller asked for the whole chain, first probe the last
+    # EARLIEST_FALLBACK_RECENT_WINDOW blocks — that covers the typical
+    # "client polling a freshly submitted userop" pattern at a fraction
+    # of the wide-scan cost. Fall through to the full "earliest" scan
+    # only if the narrow window misses.
+    if from_block_hex == "earliest":
+        latest = await _fetch_latest_block_number(
+            ethereum_node_eth_get_logs_urls,
+        )
+        if latest is not None:
+            window_from = hex(
+                max(0, latest - EARLIEST_FALLBACK_RECENT_WINDOW)
+            )
+            result = await _eth_getLogs_once(
+                ethereum_node_eth_get_logs_urls,
+                user_operation_hash, entrypoint,
+                window_from, to_block_hex,
+            )
+            if result is not None:
+                user_operation_logs_cache.set(cache_key, result)
+                return result
+
+    result = await _eth_getLogs_once(
+        ethereum_node_eth_get_logs_urls,
+        user_operation_hash, entrypoint,
+        from_block_hex, to_block_hex,
+    )
+    if result is not None:
+        user_operation_logs_cache.set(cache_key, result)
+        return result
+    return None
 
 
 transactions_cache = PersistentFIFOCache(name="transactions")
@@ -508,9 +638,29 @@ async def get_transaction_by_hash(
     if cached is not None:
         return cached
     params = [transaction_hash]
-    res: Any = await send_rpc_request_to_eth_client(
-        ethereum_node_urls, "eth_getTransactionByHash", params
-    )
+    # Same safety net as eth_getLogs/eth_getTransactionReceipt: cap wall
+    # time and treat any failure as a miss. The pending-tx retry loop
+    # below still runs on its own 1 s cadence.
+    try:
+        res: Any = await asyncio.wait_for(
+            send_rpc_request_to_eth_client(
+                ethereum_node_urls, "eth_getTransactionByHash", params,
+            ),
+            timeout=ETH_RPC_LOOKUP_TIMEOUT_S,
+        )
+    except asyncio.TimeoutError:
+        logging.error(
+            "eth_getTransactionByHash(%s) timed out after %ss; "
+            "treating as miss",
+            transaction_hash, ETH_RPC_LOOKUP_TIMEOUT_S,
+        )
+        return None
+    except Exception:
+        logging.error(
+            "eth_getTransactionByHash(%s) failed; treating as miss",
+            transaction_hash, exc_info=True,
+        )
+        return None
     if "result" in res:
         transaction = res['result']
         if (  # check if pending transaction result

--- a/voltaire_bundler/user_operation/user_operation_handler.py
+++ b/voltaire_bundler/user_operation/user_operation_handler.py
@@ -269,6 +269,23 @@ class UserOperationHandler(ABC):
                 ),
                 timeout=ETH_RPC_LOOKUP_TIMEOUT_S,
             )
+            # Same guard as get_transaction_by_hash: even with
+            # expected_key="result", the RPC layer can return a response
+            # whose error code short-circuits the retry (-32000, -32603,
+            # etc.) and leaves us with only "error". Surface that as a
+            # miss with a useful log line instead of a KeyError.
+            if "result" not in res:
+                if "error" in res:
+                    logging.error(
+                        "eth_getTransactionReceipt(%s) failed. error: %s",
+                        transaction_hash, str(res["error"]),
+                    )
+                else:
+                    logging.error(
+                        "eth_getTransactionReceipt(%s) failed. response: %s",
+                        transaction_hash, str(res),
+                    )
+                return None
             transaction = res["result"]
             if (  # pending or missing receipt — don't cache, let the caller retry
                 transaction is None or

--- a/voltaire_bundler/user_operation/user_operation_handler.py
+++ b/voltaire_bundler/user_operation/user_operation_handler.py
@@ -9,7 +9,7 @@ from eth_abi import encode, decode
 from voltaire_bundler.bundle.exceptions import UserOpReceiptFoundException
 from voltaire_bundler.mempool.sender_mempool import VerifiedUserOperation
 from voltaire_bundler.custom_types import Address
-from voltaire_bundler.utils.cache import InMemoryFIFOCache
+from voltaire_bundler.utils.cache import PersistentFIFOCache
 from voltaire_bundler.utils.eth_client_utils import \
         get_block_info, send_rpc_request_to_eth_client
 from typing import Any
@@ -252,7 +252,7 @@ class UserOperationHandler(ABC):
     async def get_transaction_receipt(
         self, transaction_hash: str
     ) -> dict | None:
-        cached = transaction_receipts_cache.get(transaction_hash)
+        cached = await transaction_receipts_cache.get(transaction_hash)
         if cached is not None:
             return cached
 
@@ -423,7 +423,7 @@ async def get_deposit_info(
 # Composite-key cache: "{entrypoint_lowercase}:{userOpHash}" -> eth_getLogs result.
 # Flattens the previous per-entrypoint nested dict (which also had a broken
 # eviction path: ``logs_cache = {}`` rebound a local, never the outer dict).
-user_operation_logs_cache = InMemoryFIFOCache(name="user_operation_logs")
+user_operation_logs_cache = PersistentFIFOCache(name="user_operation_logs")
 
 
 def del_user_operation_logs_cache_entry(
@@ -443,7 +443,7 @@ async def get_user_operation_logs_for_block_range(
     to_block_hex: str,
 ) -> dict | None:
     cache_key = f"{entrypoint.lower()}:{user_operation_hash}"
-    cached = user_operation_logs_cache.get(cache_key)
+    cached = await user_operation_logs_cache.get(cache_key)
     if cached is not None:
         return cached
     USER_OPERATIOM_EVENT_DISCRIPTOR = (
@@ -471,7 +471,7 @@ async def get_user_operation_logs_for_block_range(
         return None
 
 
-transactions_cache = InMemoryFIFOCache(name="transactions")
+transactions_cache = PersistentFIFOCache(name="transactions")
 
 
 TRANSACTION_RECEIPT_CACHED_FIELDS = (
@@ -490,7 +490,7 @@ TRANSACTION_RECEIPT_CACHED_FIELDS = (
     "effectiveGasPrice",
 )
 
-transaction_receipts_cache = InMemoryFIFOCache(name="transaction_receipts")
+transaction_receipts_cache = PersistentFIFOCache(name="transaction_receipts")
 
 
 async def get_transaction_by_hash(
@@ -504,7 +504,7 @@ async def get_transaction_by_hash(
         logging.error("get_transaction_by_hash recursion too deep.")
         return None
 
-    cached = transactions_cache.get(transaction_hash)
+    cached = await transactions_cache.get(transaction_hash)
     if cached is not None:
         return cached
     params = [transaction_hash]

--- a/voltaire_bundler/user_operation/user_operation_handler.py
+++ b/voltaire_bundler/user_operation/user_operation_handler.py
@@ -3,7 +3,6 @@ import asyncio
 from functools import cache
 import logging
 from functools import reduce
-from math import e
 
 from eth_abi import encode, decode
 from voltaire_bundler.bundle.exceptions import UserOpReceiptFoundException

--- a/voltaire_bundler/user_operation/user_operation_handler.py
+++ b/voltaire_bundler/user_operation/user_operation_handler.py
@@ -3,6 +3,7 @@ import asyncio
 from functools import cache
 import logging
 from functools import reduce
+from math import e
 
 from eth_abi import encode, decode
 from voltaire_bundler.bundle.exceptions import UserOpReceiptFoundException
@@ -81,10 +82,12 @@ class UserOperationHandler(ABC):
         return calldata
 
     async def get_user_operation_receipt(
-        self, user_operation_hash: str, entrypoint: str
+        self, user_operation_hash: str,
+        entrypoint: str,
+        validated_at_block_hex: str | None
     ) -> tuple[ReceiptInfo, UserOperationReceiptInfo] | None:
         event_log_info = await self.get_user_operation_event_log_info(
-            user_operation_hash, entrypoint
+            user_operation_hash, entrypoint, validated_at_block_hex
         )
         if event_log_info is None:
             return None
@@ -151,10 +154,13 @@ class UserOperationHandler(ABC):
         return receiptInfo, userOperationReceiptInfo
 
     async def get_user_operation_receipt_rpc(
-        self, user_operation_hash: str, entrypoint: str
+        self,
+        user_operation_hash: str,
+        entrypoint: str,
+        validated_at_block_hex: str | None,
     ) -> dict | None:
         user_operation_receipt = await self.get_user_operation_receipt(
-            user_operation_hash, entrypoint
+            user_operation_hash, entrypoint, validated_at_block_hex
         )
 
         if user_operation_receipt is None:
@@ -195,11 +201,14 @@ class UserOperationHandler(ABC):
         raise UserOpReceiptFoundException(user_operation_receipt_rpc_json)
 
     async def get_user_operation_event_log_info(
-        self, user_operation_hash: str, entrypoint: str
+        self, user_operation_hash: str,
+        entrypoint: str,
+        validated_at_block_hex: str | None
     ) -> tuple | None:
         logs: Any = await self.get_user_operation_logs(
             user_operation_hash,
             entrypoint,
+            validated_at_block_hex,
             self.logs_incremental_range,
             self.logs_number_of_ranges,
         )
@@ -257,6 +266,7 @@ class UserOperationHandler(ABC):
         self,
         user_operation_hash: str,
         entrypoint: str,
+        validated_at_block_hex: str | None,
         logs_incremental_range: int,
         logs_number_of_ranges: int,
     ):
@@ -265,8 +275,19 @@ class UserOperationHandler(ABC):
                 self.ethereum_node_eth_get_logs_urls)
 
             latest_block_number = int(block_info[0], 16)
-            earliest_block_number = latest_block_number - (
-                logs_incremental_range * logs_number_of_ranges)
+            if validated_at_block_hex is None:
+                earliest_block_number = latest_block_number - (
+                    logs_incremental_range * logs_number_of_ranges)
+            else:
+                validated_at_block_number = int(validated_at_block_hex, 16)
+                if latest_block_number - validated_at_block_number > logs_incremental_range:
+                    earliest_block_number = latest_block_number - (
+                        logs_incremental_range * logs_number_of_ranges)
+                    if earliest_block_number < validated_at_block_number:
+                        earliest_block_number = validated_at_block_number
+                else:
+                    earliest_block_number = validated_at_block_number
+
             if earliest_block_number < 0:
                 earliest_block_number = 0
             for earliest_block in range(earliest_block_number,
@@ -286,11 +307,16 @@ class UserOperationHandler(ABC):
                     return res
             return None
         else:
+            if validated_at_block_hex is not None:
+                earliest_block_hex = validated_at_block_hex
+            else:
+                earliest_block_hex = "earliest"
+
             return await get_user_operation_logs_for_block_range(
                 self.ethereum_node_eth_get_logs_urls,
                 user_operation_hash,
                 entrypoint,
-                "earliest",
+                earliest_block_hex,
                 "latest"
             )
 

--- a/voltaire_bundler/user_operation/user_operation_handler_v6.py
+++ b/voltaire_bundler/user_operation/user_operation_handler_v6.py
@@ -46,10 +46,12 @@ class UserOperationHandlerV6(UserOperationHandler):
         self.logs_number_of_ranges = logs_number_of_ranges
 
     async def get_user_operation_by_hash(
-        self, user_operation_hash: str, entrypoint: str
+        self, user_operation_hash: str,
+        entrypoint: str,
+        validated_at_block_hex: str | None
     ) -> tuple | None:
         event_log_info = await self.get_user_operation_event_log_info(
-            user_operation_hash, entrypoint
+            user_operation_hash, entrypoint, validated_at_block_hex
         )
         if event_log_info is None:
             return None
@@ -79,7 +81,7 @@ class UserOperationHandlerV6(UserOperationHandler):
             )
             del_user_operation_logs_cache_entry(user_operation_hash, entrypoint)
             event_log_info = await self.get_user_operation_event_log_info(
-                user_operation_hash, entrypoint
+                user_operation_hash, entrypoint, validated_at_block_hex
             )
             if event_log_info is None:
                 return None
@@ -140,9 +142,10 @@ class UserOperationHandlerV6(UserOperationHandler):
         user_operation_hash: str,
         entrypoint: str,
         senders_mempools,
+        validated_at_block_hex: str | None
     ) -> dict | None:
         user_operation_by_hash = await self.get_user_operation_by_hash(
-            user_operation_hash, entrypoint
+            user_operation_hash, entrypoint, validated_at_block_hex
         )
         if user_operation_by_hash is None:
             user_operation_by_hash_json = self.get_user_operation_by_hash_from_local_mempool(

--- a/voltaire_bundler/user_operation/user_operation_handler_v7v8v9.py
+++ b/voltaire_bundler/user_operation/user_operation_handler_v7v8v9.py
@@ -48,10 +48,12 @@ class UserOperationHandlerV7V8V9(UserOperationHandler):
         self.logs_number_of_ranges = logs_number_of_ranges
 
     async def get_user_operation_by_hash(
-        self, user_operation_hash: str, entrypoint: str
+        self, user_operation_hash: str,
+        entrypoint: str,
+        validated_at_block_hex: str | None
     ) -> tuple | None:
         event_log_info = await self.get_user_operation_event_log_info(
-            user_operation_hash, entrypoint
+            user_operation_hash, entrypoint, validated_at_block_hex
         )
 
         if event_log_info is None:
@@ -82,7 +84,7 @@ class UserOperationHandlerV7V8V9(UserOperationHandler):
             )
             del_user_operation_logs_cache_entry(user_operation_hash, entrypoint)
             event_log_info = await self.get_user_operation_event_log_info(
-                user_operation_hash, entrypoint
+                user_operation_hash, entrypoint, validated_at_block_hex
             )
             if event_log_info is None:
                 return None
@@ -141,9 +143,10 @@ class UserOperationHandlerV7V8V9(UserOperationHandler):
         user_operation_hash: str,
         entrypoint: str,
         senders_mempools,
+        validated_at_block_hex: str | None
     ) -> dict | None:
         user_operation_by_hash = await self.get_user_operation_by_hash(
-            user_operation_hash, entrypoint
+            user_operation_hash, entrypoint, validated_at_block_hex
         )
         if user_operation_by_hash is None:
             user_operation_by_hash_json = self.get_user_operation_by_hash_from_local_mempool(

--- a/voltaire_bundler/utils/cache.py
+++ b/voltaire_bundler/utils/cache.py
@@ -101,6 +101,13 @@ class PersistentFIFOCache:
 
         self._started: bool = False
 
+        # Startup observability: how many rows _warm_memory_from_disk
+        # pulled into memory. Free to capture (just len(rows)) so it
+        # happens on the critical path. The matching on-disk row total
+        # is fetched lazily by log_startup_status so the extra COUNT(*)
+        # doesn't extend bundler startup.
+        self._memory_loaded_at_start: int = 0
+
         PersistentFIFOCache._instances.append(self)
 
     # ------------------------------------------------------------------
@@ -225,6 +232,82 @@ class PersistentFIFOCache:
                 await cache.aclose()
             except Exception:
                 logger.exception("cache %s: aclose failed", cache.name)
+
+    @classmethod
+    def log_startup_status(cls) -> None:
+        """Emit a one-shot summary of cache tier state after start_all.
+
+        Logged in two phases. The synchronous phase reports the
+        persistent/memory-only flag plus the count of caches that fell
+        back to memory-only (all free — no SQL). The async phase
+        follows up with per-cache (on-disk rows, rows warmed into
+        memory) figures once a COUNT(*) per cache lands; that work runs
+        in a worker thread so it never blocks the event loop and is
+        scheduled AFTER start_all so it doesn't extend bundler startup.
+        Call from an async context (``asyncio.create_task`` needs a
+        running loop)."""
+        if not cls._instances:
+            return
+        persistent = [c for c in cls._instances if c.persistent]
+        memory_only = [c for c in cls._instances if not c.persistent]
+
+        if not persistent:
+            logger.info(
+                "RPC caches: memory-only mode (%d caches; persistence "
+                "disabled or soft-failed to memory-only)",
+                len(memory_only),
+            )
+            return
+
+        total_loaded = sum(c._memory_loaded_at_start for c in persistent)
+        logger.info(
+            "RPC caches: persistent mode active (%d on-disk caches, "
+            "%d rows warmed into memory at startup); per-cache on-disk "
+            "row counts to follow",
+            len(persistent), total_loaded,
+        )
+        if memory_only:
+            logger.info(
+                "  %d caches in memory-only fallback: %s",
+                len(memory_only),
+                ", ".join(c.name for c in memory_only),
+            )
+
+        asyncio.create_task(
+            cls._log_disk_row_counts(persistent),
+            name="cache-disk-row-count-report",
+        )
+
+    @classmethod
+    async def _log_disk_row_counts(
+        cls, caches: list["PersistentFIFOCache"],
+    ) -> None:
+        """Run COUNT(*) on each persistent cache off the event loop and
+        emit the per-cache (on-disk, warmed) breakdown. Best-effort:
+        per-cache errors are swallowed so a single corrupt DB doesn't
+        suppress the rest."""
+        counts: dict[str, int] = {}
+        for c in caches:
+            try:
+                counts[c.name] = await asyncio.to_thread(c._count_disk_rows)
+            except Exception:
+                logger.exception(
+                    "cache %s: disk row count failed", c.name,
+                )
+        if not counts:
+            return
+        logger.info(
+            "RPC caches: %d total rows on disk", sum(counts.values()),
+        )
+        for c in caches:
+            if c.name not in counts:
+                continue
+            logger.info(
+                "  cache %s: %d on disk, %d warmed into memory "
+                "(memory_capacity=%d, disk_capacity=%d)",
+                c.name, counts[c.name], c._memory_loaded_at_start,
+                c.memory_capacity, c.disk_capacity,
+            )
 
     # ------------------------------------------------------------------
     # Public API
@@ -539,6 +622,17 @@ class PersistentFIFOCache:
         # rows came back newest-first; reverse so we insert oldest-first.
         for key, value in reversed(rows):
             self._memory[key] = json.loads(value)
+        self._memory_loaded_at_start = len(rows)
+
+    def _count_disk_rows(self) -> int:
+        """Total on-disk row count. Used by log_startup_status; runs a
+        full COUNT(*), so don't call on a hot path."""
+        assert self._read_conn is not None
+        with self._read_lock:
+            row = self._read_conn.execute(
+                f"SELECT COUNT(*) FROM {self.name}",
+            ).fetchone()
+        return row[0] if row else 0
 
     def _evict_oldest(self) -> None:
         assert self._write_conn is not None

--- a/voltaire_bundler/utils/cache.py
+++ b/voltaire_bundler/utils/cache.py
@@ -170,6 +170,12 @@ class PersistentFIFOCache:
             self._sqlite_path = None
             self._started = True
             return
+        if self._sqlite_path is None:
+            # _warm_memory_from_disk hit a fatal JSON decode error and
+            # called _disable_disk_tier; no point spinning up a writer
+            # that has nothing to write to.
+            self._started = True
+            return
         self._write_queue = asyncio.Queue(maxsize=QUEUE_MAX)
         self._writer_task = asyncio.create_task(
             self._writer_loop(), name=f"cache-writer:{self.name}",
@@ -392,7 +398,10 @@ class PersistentFIFOCache:
     # ------------------------------------------------------------------
 
     def _enqueue_disk_write(self, key: str, value: Any) -> None:
-        if self._write_queue is None:
+        # Either branch means there's no disk tier to write to: queue
+        # never built (memory-only start) or disk tier soft-failed and
+        # cleared the path mid-flight.
+        if self._write_queue is None or self._sqlite_path is None:
             return
         try:
             self._write_queue.put_nowait((key, value))
@@ -539,7 +548,11 @@ class PersistentFIFOCache:
             self._read_conn = None
 
     def _commit_batch(self, batch: list[tuple[str, Any]]) -> None:
-        assert self._write_conn is not None
+        # Disk tier may have been disabled mid-flight (e.g. by a fatal
+        # JSON decode error in _disk_get). Drop the batch silently — the
+        # data is still in memory; persistence is the only thing lost.
+        if self._write_conn is None:
+            return
         cur = self._write_conn.cursor()
         # IMMEDIATE takes the write lock upfront so concurrent bundlers
         # serialize cleanly via busy_timeout, rather than getting partway
@@ -586,7 +599,8 @@ class PersistentFIFOCache:
             raise
 
     def _disk_get(self, key: str) -> Any | None:
-        assert self._read_conn is not None
+        if self._read_conn is None:
+            return None
         with self._read_lock:
             cur = self._read_conn.execute(
                 f"SELECT value FROM {self.name} WHERE key = ?", (key,),
@@ -594,10 +608,20 @@ class PersistentFIFOCache:
             row = cur.fetchone()
         if row is None:
             return None
-        return json.loads(row[0])
+        try:
+            return json.loads(row[0])
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                "cache %s: malformed JSON for key %s (%s); "
+                "disabling disk tier and treating this lookup as a miss",
+                self.name, key, exc,
+            )
+            self._disable_disk_tier()
+            return None
 
     def _disk_get_many(self, keys: list[str]) -> dict[str, Any]:
-        assert self._read_conn is not None
+        if self._read_conn is None:
+            return {}
         # SQLite has a SQLITE_LIMIT_VARIABLE_NUMBER ceiling (default 999 on
         # older builds, 32766 on newer ones). Real callers pass a handful
         # of keys; this guard catches accidental misuse without imposing
@@ -614,14 +638,29 @@ class PersistentFIFOCache:
                 keys,
             )
             rows = cur.fetchall()
-        return {key: json.loads(value) for key, value in rows}
+        out: dict[str, Any] = {}
+        for key, value in rows:
+            try:
+                out[key] = json.loads(value)
+            except json.JSONDecodeError as exc:
+                logger.warning(
+                    "cache %s: malformed JSON for key %s (%s); "
+                    "disabling disk tier and skipping the bad row",
+                    self.name, key, exc,
+                )
+                self._disable_disk_tier()
+                # Return whatever we already decoded — the caller treats
+                # absent keys as misses, which is the correct degradation.
+                return out
+        return out
 
     def _warm_memory_from_disk(self) -> None:
         """Preload the most-recent ``memory_capacity`` rows into the hot
         tier so the first reads after a restart don't need disk fallback.
         Inserts in ascending seq order so the OrderedDict's FIFO order
         mirrors on-disk insertion order (oldest first, newest last)."""
-        assert self._read_conn is not None
+        if self._read_conn is None:
+            return
         with self._read_lock:
             cur = self._read_conn.execute(
                 f"SELECT key, value FROM {self.name} "
@@ -630,9 +669,41 @@ class PersistentFIFOCache:
             )
             rows = cur.fetchall()
         # rows came back newest-first; reverse so we insert oldest-first.
+        loaded = 0
         for key, value in reversed(rows):
-            self._memory[key] = json.loads(value)
-        self._memory_loaded_at_start = len(rows)
+            try:
+                self._memory[key] = json.loads(value)
+            except json.JSONDecodeError as exc:
+                logger.warning(
+                    "cache %s: malformed JSON for key %s during warmup "
+                    "(%s); disabling disk tier and continuing memory-only",
+                    self.name, key, exc,
+                )
+                self._disable_disk_tier()
+                break
+            loaded += 1
+        self._memory_loaded_at_start = loaded
+
+    def _disable_disk_tier(self) -> None:
+        """Soft-fail the disk tier after an unrecoverable error (e.g.
+        malformed JSON in a row, which signals a corrupt DB file). Closes
+        both SQLite connections and clears ``_sqlite_path`` so subsequent
+        reads stay memory-only. Idempotent — safe to call from any
+        worker thread, and from the writer task path.
+
+        The writer task lingers but its commits no-op once
+        ``_write_conn`` is None; new ``set``/``delete`` calls also no-op
+        (``_enqueue_disk_write`` checks ``_sqlite_path``)."""
+        if self._sqlite_path is None:
+            return
+        self._sqlite_path = None
+        try:
+            self._close_conns()
+        except Exception:
+            logger.exception(
+                "cache %s: closing connections after disk-tier disable failed",
+                self.name,
+            )
 
     def _count_disk_rows(self) -> int:
         """Total on-disk row count. Used by log_startup_status; runs a
@@ -645,7 +716,8 @@ class PersistentFIFOCache:
         return row[0] if row else 0
 
     def _evict_oldest(self) -> None:
-        assert self._write_conn is not None
+        if self._write_conn is None:
+            return
         cur = self._write_conn.cursor()
         cur.execute(f"SELECT COUNT(*) FROM {self.name}")
         count = cur.fetchone()[0]

--- a/voltaire_bundler/utils/cache.py
+++ b/voltaire_bundler/utils/cache.py
@@ -106,6 +106,9 @@ class PersistentFIFOCache:
         self._sqlite_path = sqlite_path
         self._sqlite_cache_size_kb = sqlite_cache_size_kb
         await asyncio.to_thread(self._open_db)
+        # Preload the freshest entries from disk so the first batch of RPCs
+        # after a restart get hot hits instead of falling through to disk.
+        await asyncio.to_thread(self._warm_memory_from_disk)
         self._write_queue = asyncio.Queue(maxsize=QUEUE_MAX)
         self._writer_task = asyncio.create_task(
             self._writer_loop(), name=f"cache-writer:{self.name}",
@@ -358,6 +361,23 @@ class PersistentFIFOCache:
         if row is None:
             return None
         return json.loads(row[0])
+
+    def _warm_memory_from_disk(self) -> None:
+        """Preload the most-recent ``memory_capacity`` rows into the hot
+        tier so the first reads after a restart don't need disk fallback.
+        Inserts in ascending seq order so the OrderedDict's FIFO order
+        mirrors on-disk insertion order (oldest first, newest last)."""
+        assert self._read_conn is not None
+        with self._read_lock:
+            cur = self._read_conn.execute(
+                f"SELECT key, value FROM {self.name} "
+                f"ORDER BY seq DESC LIMIT ?",
+                (self.memory_capacity,),
+            )
+            rows = cur.fetchall()
+        # rows came back newest-first; reverse so we insert oldest-first.
+        for key, value in reversed(rows):
+            self._memory[key] = json.loads(value)
 
     def _evict_oldest(self) -> None:
         assert self._write_conn is not None

--- a/voltaire_bundler/utils/cache.py
+++ b/voltaire_bundler/utils/cache.py
@@ -542,10 +542,18 @@ class PersistentFIFOCache:
                 self._write_conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
                 self._write_conn.close()
         finally:
-            if self._read_conn is not None:
-                self._read_conn.close()
-            self._write_conn = None
-            self._read_conn = None
+            # Hold _read_lock across the read-conn close+null so we don't
+            # race a reader that already passed the None-check and is
+            # about to (or currently is) executing a SELECT inside the
+            # same lock. Without this, _disable_disk_tier on the
+            # malformed-JSON path could close the connection while a
+            # sibling _disk_get/_disk_get_many holds the lock, surfacing
+            # as sqlite3.ProgrammingError("closed database").
+            with self._read_lock:
+                if self._read_conn is not None:
+                    self._read_conn.close()
+                self._write_conn = None
+                self._read_conn = None
 
     def _commit_batch(self, batch: list[tuple[str, Any]]) -> None:
         # Disk tier may have been disabled mid-flight (e.g. by a fatal
@@ -599,9 +607,13 @@ class PersistentFIFOCache:
             raise
 
     def _disk_get(self, key: str) -> Any | None:
-        if self._read_conn is None:
-            return None
+        # Check _read_conn INSIDE the lock — _close_conns sets it to None
+        # under the same lock, so a check outside would allow a stale
+        # "not None" observation to ride a now-closed connection into
+        # the SELECT below.
         with self._read_lock:
+            if self._read_conn is None:
+                return None
             cur = self._read_conn.execute(
                 f"SELECT value FROM {self.name} WHERE key = ?", (key,),
             )
@@ -620,8 +632,6 @@ class PersistentFIFOCache:
             return None
 
     def _disk_get_many(self, keys: list[str]) -> dict[str, Any]:
-        if self._read_conn is None:
-            return {}
         # SQLite has a SQLITE_LIMIT_VARIABLE_NUMBER ceiling (default 999 on
         # older builds, 32766 on newer ones). Real callers pass a handful
         # of keys; this guard catches accidental misuse without imposing
@@ -631,7 +641,11 @@ class PersistentFIFOCache:
                 f"get_many: {len(keys)} keys exceeds the per-query limit"
             )
         placeholders = ",".join("?" * len(keys))
+        # Check _read_conn INSIDE the lock for the same reason as
+        # _disk_get — _close_conns nulls it under the same lock.
         with self._read_lock:
+            if self._read_conn is None:
+                return {}
             cur = self._read_conn.execute(
                 f"SELECT key, value FROM {self.name} "
                 f"WHERE key IN ({placeholders})",

--- a/voltaire_bundler/utils/cache.py
+++ b/voltaire_bundler/utils/cache.py
@@ -506,11 +506,11 @@ class PersistentFIFOCache:
                 );
                 """
             )
-            row = self._write_conn.execute(
-                "SELECT next_seq FROM cache_meta WHERE table_name = ?",
-                (self.name,),
-            ).fetchone()
-            self._next_seq = row[0] if row else 0
+            # next_seq is read inside _commit_batch under BEGIN IMMEDIATE so
+            # concurrent bundlers sharing this SQLite file allocate disjoint
+            # sequence ranges. Caching it here at startup was racy: two
+            # processes would each load the same value and both advance an
+            # in-memory copy, producing overlapping seq writes.
         except Exception:
             # Roll back any partial state so ``start``'s soft-fail path
             # doesn't see a half-open cache. Best-effort close — we're
@@ -547,6 +547,15 @@ class PersistentFIFOCache:
         # first INSERT.
         cur.execute("BEGIN IMMEDIATE")
         try:
+            # Read the authoritative next_seq inside the write lock so a
+            # second bundler that committed since our last batch doesn't
+            # cause us to reuse its seq values. The in-memory _next_seq
+            # is only a hint; this is the source of truth.
+            row = cur.execute(
+                "SELECT next_seq FROM cache_meta WHERE table_name = ?",
+                (self.name,),
+            ).fetchone()
+            next_seq = row[0] if row else 0
             for key, value in batch:
                 if value is _TOMBSTONE:
                     cur.execute(
@@ -561,16 +570,17 @@ class PersistentFIFOCache:
                         (
                             key,
                             json.dumps(value).encode("utf-8"),
-                            self._next_seq,
+                            next_seq,
                         ),
                     )
-                    self._next_seq += 1
+                    next_seq += 1
             cur.execute(
                 "INSERT OR REPLACE INTO cache_meta (table_name, next_seq) "
                 "VALUES (?, ?)",
-                (self.name, self._next_seq),
+                (self.name, next_seq),
             )
             cur.execute("COMMIT")
+            self._next_seq = next_seq
         except Exception:
             cur.execute("ROLLBACK")
             raise

--- a/voltaire_bundler/utils/cache.py
+++ b/voltaire_bundler/utils/cache.py
@@ -217,6 +217,32 @@ class PersistentFIFOCache:
                 self._memory.popitem(last=False)
         return v
 
+    async def get_many(self, keys: list[str]) -> dict[str, Any]:
+        """Bulk lookup. Returns a dict mapping each key that's present (in
+        either tier) to its value; keys absent from both tiers are absent
+        from the result. Memory misses for ALL keys go to disk in a single
+        ``SELECT … WHERE key IN (…)`` instead of one round trip per key —
+        the difference matters when a hot-path handler probes 4+ keys at
+        once (e.g. the seen-cache fan-out across entrypoint versions)."""
+        if not keys:
+            return {}
+        found: dict[str, Any] = {}
+        misses: list[str] = []
+        for k in keys:
+            v = self._memory.get(k)
+            if v is not None:
+                found[k] = v
+            else:
+                misses.append(k)
+        if misses and self._read_conn is not None:
+            disk_hits = await asyncio.to_thread(self._disk_get_many, misses)
+            for k, v in disk_hits.items():
+                found[k] = v
+                self._memory[k] = v
+                if len(self._memory) > self.memory_capacity:
+                    self._memory.popitem(last=False)
+        return found
+
     def set(self, key: str, value: Any) -> None:
         # Hot tier: insert (or overwrite in place — OrderedDict preserves
         # position on overwrite, keeping the FIFO order pinned to the
@@ -421,6 +447,26 @@ class PersistentFIFOCache:
         if row is None:
             return None
         return json.loads(row[0])
+
+    def _disk_get_many(self, keys: list[str]) -> dict[str, Any]:
+        assert self._read_conn is not None
+        # SQLite has a SQLITE_LIMIT_VARIABLE_NUMBER ceiling (default 999 on
+        # older builds, 32766 on newer ones). Real callers pass a handful
+        # of keys; this guard catches accidental misuse without imposing
+        # a chunking dance for the common case.
+        if len(keys) > 500:
+            raise ValueError(
+                f"get_many: {len(keys)} keys exceeds the per-query limit"
+            )
+        placeholders = ",".join("?" * len(keys))
+        with self._read_lock:
+            cur = self._read_conn.execute(
+                f"SELECT key, value FROM {self.name} "
+                f"WHERE key IN ({placeholders})",
+                keys,
+            )
+            rows = cur.fetchall()
+        return {key: json.loads(value) for key, value in rows}
 
     def _warm_memory_from_disk(self) -> None:
         """Preload the most-recent ``memory_capacity`` rows into the hot

--- a/voltaire_bundler/utils/cache.py
+++ b/voltaire_bundler/utils/cache.py
@@ -1,0 +1,39 @@
+"""
+In-memory cache wrapper used by the bundler RPC layer.
+
+Phase 1 of the caching refactor: this class wraps the previous module-level
+``dict`` caches behind a small ``get/set/delete`` interface so subsequent
+phases can swap the storage layer (per-entry FIFO eviction, on-disk
+persistence) without changing call sites.
+
+Eviction matches the legacy behavior exactly: when the underlying dict
+grows past ``capacity`` entries on insert, the whole dict is replaced with
+an empty one. Per-entry FIFO eviction lands in phase 2.
+"""
+from typing import Any
+
+
+class InMemoryFIFOCache:
+    def __init__(self, name: str, capacity: int = 10_000) -> None:
+        self.name = name
+        self.capacity = capacity
+        self._data: dict[str, Any] = {}
+
+    def get(self, key: str) -> Any | None:
+        return self._data.get(key)
+
+    def set(self, key: str, value: Any) -> None:
+        # Preserve the legacy "drop everything when full" policy until phase 2
+        # swaps it for OrderedDict.popitem(last=False).
+        if len(self._data) > self.capacity:
+            self._data = {}
+        self._data[key] = value
+
+    def delete(self, key: str) -> None:
+        self._data.pop(key, None)
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._data
+
+    def __len__(self) -> int:
+        return len(self._data)

--- a/voltaire_bundler/utils/cache.py
+++ b/voltaire_bundler/utils/cache.py
@@ -18,6 +18,26 @@ enabled so readers never wait on the writer.
 When ``start`` is called without a ``sqlite_path`` (or never called), the
 cache behaves as a memory-only FIFO: ``get`` is still async, but never
 falls through to disk.
+
+Eviction-order discrepancy on overwrites
+----------------------------------------
+The two tiers diverge on how they treat ``set(k, v)`` for a key that's
+already present:
+
+- The memory ``OrderedDict`` keeps the key in its **original** insertion
+  slot (strict FIFO — overwrites do not refresh recency).
+- The disk side uses ``INSERT OR REPLACE``, which deletes the existing
+  row and reinserts with a fresh ``seq``, so the entry moves to the
+  **FIFO-newest** position on disk.
+
+After a restart, ``warm_memory_from_disk`` loads ``memory_capacity``
+rows by ``seq DESC`` — i.e. the disk view wins, and a key that was
+"old" in the previous session's memory comes back as "newest" in
+memory. This is intentional today because all current callers store
+deterministic values (chain-immutable logs/receipts/txs, or
+``seen_cache`` block hex where either bundler's value is correct), so
+the eviction-priority flip is invisible. If you add a caller that
+overwrites with different semantics, audit this.
 """
 from __future__ import annotations
 

--- a/voltaire_bundler/utils/cache.py
+++ b/voltaire_bundler/utils/cache.py
@@ -321,6 +321,11 @@ class PersistentFIFOCache:
                     f"PRAGMA cache_size  = -{self._sqlite_cache_size_kb}",
                 )
                 conn.execute("PRAGMA mmap_size    = 67108864")  # 64 MB virtual
+                # Multi-bundler safety: when another process on the same
+                # chain shares this file and holds the WAL write lock, wait
+                # up to 5 s rather than failing the commit. Without this,
+                # any concurrent write contention silently drops the batch.
+                conn.execute("PRAGMA busy_timeout = 5000")
 
             self._write_conn.executescript(
                 f"""
@@ -372,7 +377,11 @@ class PersistentFIFOCache:
     def _commit_batch(self, batch: list[tuple[str, Any]]) -> None:
         assert self._write_conn is not None
         cur = self._write_conn.cursor()
-        cur.execute("BEGIN")
+        # IMMEDIATE takes the write lock upfront so concurrent bundlers
+        # serialize cleanly via busy_timeout, rather than getting partway
+        # through a deferred transaction and hitting SQLITE_BUSY on the
+        # first INSERT.
+        cur.execute("BEGIN IMMEDIATE")
         try:
             for key, value in batch:
                 if value is _TOMBSTONE:

--- a/voltaire_bundler/utils/cache.py
+++ b/voltaire_bundler/utils/cache.py
@@ -294,6 +294,21 @@ class PersistentFIFOCache:
 
     async def _writer_loop(self) -> None:
         assert self._write_queue is not None
+        # One-shot cleanup of any overage accumulated across previous
+        # sessions. ``_writes_since_evict`` only triggers in-session
+        # eviction after 1000 writes; a frequently-restarting bundler
+        # that never crosses that threshold would otherwise let the disk
+        # file drift past disk_capacity indefinitely. Doing this here (in
+        # the writer task) instead of in start() keeps startup latency
+        # untouched — the writer task gets created at the end of start()
+        # and the eviction runs in the background. Errors are logged and
+        # swallowed; nothing here is load-bearing.
+        try:
+            await asyncio.to_thread(self._evict_oldest)
+        except Exception:
+            logger.exception(
+                "cache %s: startup eviction failed", self.name,
+            )
         while True:
             first = await self._write_queue.get()
             batch: list[tuple[str, Any]] = [first]

--- a/voltaire_bundler/utils/cache.py
+++ b/voltaire_bundler/utils/cache.py
@@ -133,6 +133,19 @@ class PersistentFIFOCache:
         self._started = False
 
     @classmethod
+    def apply_capacity_multipliers(
+        cls, memory_mult: float, disk_mult: float,
+    ) -> None:
+        """Scale every registered cache's capacities by the given multipliers.
+        Must be called BEFORE ``start_all`` so warm-on-start observes the
+        new memory cap and disk eviction uses the new disk cap."""
+        if memory_mult <= 0 or disk_mult <= 0:
+            raise ValueError("cache size multipliers must be positive")
+        for cache in cls._instances:
+            cache.memory_capacity = max(1, int(cache.memory_capacity * memory_mult))
+            cache.disk_capacity = max(1, int(cache.disk_capacity * disk_mult))
+
+    @classmethod
     async def start_all(
         cls,
         cache_dir: Path | None,

--- a/voltaire_bundler/utils/cache.py
+++ b/voltaire_bundler/utils/cache.py
@@ -132,6 +132,13 @@ class PersistentFIFOCache:
         self._sqlite_cache_size_kb = sqlite_cache_size_kb
         try:
             await asyncio.to_thread(self._open_db)
+            # Preload the freshest entries from disk so the first batch
+            # of RPCs after a restart get hot hits instead of falling
+            # through to disk. Keep this inside the same try/except as
+            # _open_db: a corrupt or partially-readable DB can fail at
+            # SELECT time, and we'd rather degrade to memory-only than
+            # abort start().
+            await asyncio.to_thread(self._warm_memory_from_disk)
         except (OSError, sqlite3.Error) as exc:
             # Most commonly: cache_dir isn't writable (container without a
             # writable HOME, hardened systemd unit, read-only filesystem),
@@ -145,12 +152,17 @@ class PersistentFIFOCache:
                 "--clear_cache to wipe a corrupted DB.",
                 self.name, type(exc).__name__, exc,
             )
+            # _open_db rolls back its own connections on failure, but a
+            # warmup-time error leaves them open — close them here so the
+            # memory-only path doesn't leak file handles.
+            if self._write_conn is not None or self._read_conn is not None:
+                try:
+                    await asyncio.to_thread(self._close_conns)
+                except Exception:
+                    pass
             self._sqlite_path = None
             self._started = True
             return
-        # Preload the freshest entries from disk so the first batch of RPCs
-        # after a restart get hot hits instead of falling through to disk.
-        await asyncio.to_thread(self._warm_memory_from_disk)
         self._write_queue = asyncio.Queue(maxsize=QUEUE_MAX)
         self._writer_task = asyncio.create_task(
             self._writer_loop(), name=f"cache-writer:{self.name}",

--- a/voltaire_bundler/utils/cache.py
+++ b/voltaire_bundler/utils/cache.py
@@ -1,42 +1,383 @@
 """
-In-memory FIFO cache wrapper used by the bundler RPC layer.
+FIFO cache with an optional on-disk cold tier (SQLite).
 
-Strict FIFO eviction: ``set`` of a new key past capacity drops the single
-oldest entry. ``set`` of an existing key updates the value in place and
-does NOT refresh insertion order — older entries don't get a second life
-just because they were re-written.
+Hot tier: ``OrderedDict`` capped at ``memory_capacity``. Strict FIFO —
+overwrites of existing keys do NOT refresh insertion order.
 
-The class exposes a small ``get/set/delete`` interface so the storage
-layer can be swapped in later phases (on-disk SQLite tier) without
-touching call sites.
+Cold tier (enabled when ``start(sqlite_path=...)`` is called with a path):
+a single SQLite table keyed by ``key``, with a monotonic ``seq`` column for
+FIFO ordering. Writes are non-blocking on the RPC path — ``set`` enqueues
+onto a bounded ``asyncio.Queue`` whose consumer is a background writer
+task that batches up to ``BATCH_MAX`` writes per transaction and commits
+via ``asyncio.to_thread``.
+
+Reads consult memory first; on miss, a ``SELECT`` runs via
+``asyncio.to_thread`` against a dedicated read connection. WAL mode is
+enabled so readers never wait on the writer.
+
+When ``start`` is called without a ``sqlite_path`` (or never called), the
+cache behaves as a memory-only FIFO: ``get`` is still async, but never
+falls through to disk.
 """
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import sqlite3
+import threading
 from collections import OrderedDict
+from pathlib import Path
 from typing import Any
 
+logger = logging.getLogger(__name__)
 
-class InMemoryFIFOCache:
-    def __init__(self, name: str, capacity: int = 10_000) -> None:
+# Sentinel used internally to represent a delete in the write queue. Translated
+# to a SQL DELETE by the writer task. Distinct from a stored ``None`` value.
+_TOMBSTONE: object = object()
+
+# Tuning knobs — kept module-level so they're easy to find and override in tests.
+BATCH_MAX = 100              # max writes coalesced into a single SQLite txn
+QUEUE_MAX = 10_000           # max disk-writes queued before we drop-oldest
+EVICT_EVERY_N_WRITES = 1000  # how often the writer task prunes excess rows
+
+# A SQL identifier safe enough to interpolate into CREATE/SELECT/etc. The cache
+# ``name`` is used as both the table name and a key in cache_meta.
+_SAFE_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class PersistentFIFOCache:
+    # Process-wide registry so the bundler entry point can start/stop all
+    # caches in one shot without threading them through every constructor.
+    _instances: list["PersistentFIFOCache"] = []
+
+    def __init__(
+        self,
+        name: str,
+        memory_capacity: int = 10_000,
+        disk_capacity: int = 500_000,
+    ) -> None:
+        if not _SAFE_NAME.match(name):
+            # ``name`` is interpolated into SQL via f-strings; reject anything
+            # that could escape an identifier.
+            raise ValueError(f"cache name must be a SQL identifier: {name!r}")
         self.name = name
-        self.capacity = capacity
-        self._data: OrderedDict[str, Any] = OrderedDict()
+        self.memory_capacity = memory_capacity
+        self.disk_capacity = disk_capacity
 
-    def get(self, key: str) -> Any | None:
-        # Pure FIFO: reads do not promote — order is fixed at insertion time.
-        return self._data.get(key)
+        self._memory: OrderedDict[str, Any] = OrderedDict()
+
+        # Disk-tier state. None until start(sqlite_path=...) is called.
+        self._sqlite_path: Path | None = None
+        self._sqlite_cache_size_kb: int = 8_000
+        self._write_conn: sqlite3.Connection | None = None
+        self._read_conn: sqlite3.Connection | None = None
+        self._read_lock = threading.Lock()
+        self._write_queue: asyncio.Queue[tuple[str, Any]] | None = None
+        self._writer_task: asyncio.Task[None] | None = None
+        self._next_seq: int = 0
+        self._writes_since_evict: int = 0
+
+        self._started: bool = False
+
+        PersistentFIFOCache._instances.append(self)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    @property
+    def persistent(self) -> bool:
+        return self._sqlite_path is not None
+
+    async def start(
+        self,
+        sqlite_path: Path | None = None,
+        sqlite_cache_size_kb: int = 8_000,
+    ) -> None:
+        """Start the cache. With ``sqlite_path=None``, runs in memory-only
+        mode. Idempotent — repeat calls are a no-op."""
+        if self._started:
+            return
+        if sqlite_path is None:
+            self._started = True
+            return
+        self._sqlite_path = sqlite_path
+        self._sqlite_cache_size_kb = sqlite_cache_size_kb
+        await asyncio.to_thread(self._open_db)
+        self._write_queue = asyncio.Queue(maxsize=QUEUE_MAX)
+        self._writer_task = asyncio.create_task(
+            self._writer_loop(), name=f"cache-writer:{self.name}",
+        )
+        self._started = True
+
+    async def aclose(self) -> None:
+        if not self._started:
+            return
+        if self._write_queue is not None:
+            # Wait for all enqueued writes to be flushed.
+            await self._write_queue.join()
+        if self._writer_task is not None:
+            self._writer_task.cancel()
+            try:
+                await self._writer_task
+            except asyncio.CancelledError:
+                pass
+            self._writer_task = None
+        if self._write_conn is not None:
+            await asyncio.to_thread(self._close_conns)
+        self._started = False
+
+    @classmethod
+    async def start_all(
+        cls,
+        cache_dir: Path | None,
+        sqlite_cache_size_kb: int = 8_000,
+    ) -> None:
+        """Start every registered cache instance.
+
+        ``cache_dir`` of ``None`` means memory-only mode; otherwise each
+        cache opens ``{cache_dir}/{name}.sqlite``."""
+        for cache in cls._instances:
+            if cache_dir is None:
+                await cache.start(sqlite_path=None)
+            else:
+                await cache.start(
+                    sqlite_path=cache_dir / f"{cache.name}.sqlite",
+                    sqlite_cache_size_kb=sqlite_cache_size_kb,
+                )
+
+    @classmethod
+    async def aclose_all(cls) -> None:
+        for cache in cls._instances:
+            try:
+                await cache.aclose()
+            except Exception:
+                logger.exception("cache %s: aclose failed", cache.name)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def get(self, key: str) -> Any | None:
+        # Memory first — the hot path.
+        v = self._memory.get(key)
+        if v is not None:
+            return v
+        # No disk tier configured: memory miss is a hard miss.
+        if self._read_conn is None:
+            return None
+        # Cold tier fallback. Cheap if the page is hot in the SQLite cache or
+        # the OS page cache (via mmap); a few hundred µs otherwise.
+        v = await asyncio.to_thread(self._disk_get, key)
+        if v is not None:
+            # Promote so a follow-up read is a hot hit. Doesn't queue a disk
+            # write — the entry is already durable.
+            self._memory[key] = v
+            if len(self._memory) > self.memory_capacity:
+                self._memory.popitem(last=False)
+        return v
 
     def set(self, key: str, value: Any) -> None:
-        # OrderedDict preserves the existing position on overwrite, which is
-        # the strict-FIFO behavior we want. Only new keys grow the dict and
-        # can trigger eviction.
-        self._data[key] = value
-        if len(self._data) > self.capacity:
-            self._data.popitem(last=False)
+        # Hot tier: insert (or overwrite in place — OrderedDict preserves
+        # position on overwrite, keeping the FIFO order pinned to the
+        # ORIGINAL insertion time).
+        self._memory[key] = value
+        if len(self._memory) > self.memory_capacity:
+            self._memory.popitem(last=False)
+        # Cold tier: hand off to the writer task. Sub-µs.
+        self._enqueue_disk_write(key, value)
 
     def delete(self, key: str) -> None:
-        self._data.pop(key, None)
+        self._memory.pop(key, None)
+        self._enqueue_disk_write(key, _TOMBSTONE)
 
     def __contains__(self, key: str) -> bool:
-        return key in self._data
+        # Memory-only check; intentional, since async ``in`` doesn't exist.
+        return key in self._memory
 
     def __len__(self) -> int:
-        return len(self._data)
+        return len(self._memory)
+
+    # ------------------------------------------------------------------
+    # Internal: write queue
+    # ------------------------------------------------------------------
+
+    def _enqueue_disk_write(self, key: str, value: Any) -> None:
+        if self._write_queue is None:
+            return
+        try:
+            self._write_queue.put_nowait((key, value))
+            return
+        except asyncio.QueueFull:
+            pass
+        # Drop the oldest queued write to make room. The dropped entry stays
+        # in memory; it just won't be durable. This keeps the RPC path
+        # non-blocking under pathological write bursts.
+        try:
+            self._write_queue.get_nowait()
+            self._write_queue.task_done()
+        except asyncio.QueueEmpty:
+            pass
+        try:
+            self._write_queue.put_nowait((key, value))
+        except asyncio.QueueFull:
+            pass
+        logger.warning(
+            "cache %s: write queue full, dropped oldest", self.name,
+        )
+
+    async def _writer_loop(self) -> None:
+        assert self._write_queue is not None
+        while True:
+            first = await self._write_queue.get()
+            batch: list[tuple[str, Any]] = [first]
+            # Opportunistically drain more without awaiting — batches grow
+            # under load, stay small under idle.
+            try:
+                while len(batch) < BATCH_MAX:
+                    batch.append(self._write_queue.get_nowait())
+            except asyncio.QueueEmpty:
+                pass
+            try:
+                await asyncio.to_thread(self._commit_batch, batch)
+                self._writes_since_evict += len(batch)
+                if self._writes_since_evict >= EVICT_EVERY_N_WRITES:
+                    await asyncio.to_thread(self._evict_oldest)
+                    self._writes_since_evict = 0
+            except Exception:
+                logger.exception(
+                    "cache %s: batch commit failed", self.name,
+                )
+            finally:
+                for _ in batch:
+                    self._write_queue.task_done()
+
+    # ------------------------------------------------------------------
+    # Internal: SQLite (all runs in a worker thread via asyncio.to_thread)
+    # ------------------------------------------------------------------
+
+    def _open_db(self) -> None:
+        assert self._sqlite_path is not None
+        self._sqlite_path.parent.mkdir(parents=True, exist_ok=True)
+        # isolation_level=None puts us in autocommit mode; transactions are
+        # managed explicitly via BEGIN/COMMIT.
+        self._write_conn = sqlite3.connect(
+            str(self._sqlite_path),
+            check_same_thread=False,
+            isolation_level=None,
+        )
+        self._read_conn = sqlite3.connect(
+            str(self._sqlite_path),
+            check_same_thread=False,
+            isolation_level=None,
+        )
+        for conn in (self._write_conn, self._read_conn):
+            # PRAGMAs are per-connection; both conns need them.
+            conn.execute("PRAGMA journal_mode = WAL")
+            conn.execute("PRAGMA synchronous  = NORMAL")
+            conn.execute("PRAGMA temp_store   = MEMORY")
+            conn.execute(f"PRAGMA cache_size  = -{self._sqlite_cache_size_kb}")
+            conn.execute("PRAGMA mmap_size    = 67108864")  # 64 MB virtual
+
+        self._write_conn.executescript(
+            f"""
+            CREATE TABLE IF NOT EXISTS {self.name} (
+                key   TEXT    PRIMARY KEY,
+                value BLOB    NOT NULL,
+                seq   INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS {self.name}_seq
+                ON {self.name} (seq);
+            CREATE TABLE IF NOT EXISTS cache_meta (
+                table_name TEXT PRIMARY KEY,
+                next_seq   INTEGER NOT NULL
+            );
+            """
+        )
+        row = self._write_conn.execute(
+            "SELECT next_seq FROM cache_meta WHERE table_name = ?",
+            (self.name,),
+        ).fetchone()
+        self._next_seq = row[0] if row else 0
+
+    def _close_conns(self) -> None:
+        try:
+            if self._write_conn is not None:
+                # Roll the WAL into the main DB so a cold restart doesn't
+                # have to replay a large WAL.
+                self._write_conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                self._write_conn.close()
+        finally:
+            if self._read_conn is not None:
+                self._read_conn.close()
+            self._write_conn = None
+            self._read_conn = None
+
+    def _commit_batch(self, batch: list[tuple[str, Any]]) -> None:
+        assert self._write_conn is not None
+        cur = self._write_conn.cursor()
+        cur.execute("BEGIN")
+        try:
+            for key, value in batch:
+                if value is _TOMBSTONE:
+                    cur.execute(
+                        f"DELETE FROM {self.name} WHERE key = ?", (key,),
+                    )
+                else:
+                    # INSERT OR REPLACE bumps seq so the entry moves to the
+                    # FIFO-newest position even on overwrite.
+                    cur.execute(
+                        f"INSERT OR REPLACE INTO {self.name} "
+                        "(key, value, seq) VALUES (?, ?, ?)",
+                        (
+                            key,
+                            json.dumps(value).encode("utf-8"),
+                            self._next_seq,
+                        ),
+                    )
+                    self._next_seq += 1
+            cur.execute(
+                "INSERT OR REPLACE INTO cache_meta (table_name, next_seq) "
+                "VALUES (?, ?)",
+                (self.name, self._next_seq),
+            )
+            cur.execute("COMMIT")
+        except Exception:
+            cur.execute("ROLLBACK")
+            raise
+
+    def _disk_get(self, key: str) -> Any | None:
+        assert self._read_conn is not None
+        with self._read_lock:
+            cur = self._read_conn.execute(
+                f"SELECT value FROM {self.name} WHERE key = ?", (key,),
+            )
+            row = cur.fetchone()
+        if row is None:
+            return None
+        return json.loads(row[0])
+
+    def _evict_oldest(self) -> None:
+        assert self._write_conn is not None
+        cur = self._write_conn.cursor()
+        cur.execute(f"SELECT COUNT(*) FROM {self.name}")
+        count = cur.fetchone()[0]
+        if count <= self.disk_capacity:
+            return
+        overflow = count - self.disk_capacity
+        cur.execute("BEGIN")
+        try:
+            # Delete the ``overflow`` oldest rows (lowest seq).
+            cur.execute(
+                f"DELETE FROM {self.name} WHERE seq IN "
+                f"(SELECT seq FROM {self.name} ORDER BY seq LIMIT ?)",
+                (overflow,),
+            )
+            cur.execute("COMMIT")
+        except Exception:
+            cur.execute("ROLLBACK")
+            raise
+
+

--- a/voltaire_bundler/utils/cache.py
+++ b/voltaire_bundler/utils/cache.py
@@ -219,6 +219,14 @@ class PersistentFIFOCache:
     # ------------------------------------------------------------------
 
     async def get(self, key: str) -> Any | None:
+        # ``is not None`` is the hit/miss signal, so a cached ``None`` is
+        # indistinguishable from "not in cache" and triggers a refetch.
+        # That's the right behavior for this codebase: every key maps to
+        # chain-derived state that can change over time (a userop hash
+        # with no log today may have one after the next bundle), so
+        # there's no such thing as an authoritative cached "no result".
+        # If you wire up a caller whose miss IS final, this needs a
+        # sentinel-based signal instead.
         # Memory first — the hot path.
         v = self._memory.get(key)
         if v is not None:

--- a/voltaire_bundler/utils/cache.py
+++ b/voltaire_bundler/utils/cache.py
@@ -97,7 +97,12 @@ class PersistentFIFOCache:
         sqlite_cache_size_kb: int = 8_000,
     ) -> None:
         """Start the cache. With ``sqlite_path=None``, runs in memory-only
-        mode. Idempotent — repeat calls are a no-op."""
+        mode. Idempotent — repeat calls are a no-op.
+
+        If the disk tier is requested but the SQLite file can't be opened
+        (unwritable directory, full disk, corruption, etc.), the cache
+        soft-fails to memory-only mode with a warning. The bundler still
+        runs; the next restart re-attempts the disk tier."""
         if self._started:
             return
         if sqlite_path is None:
@@ -105,7 +110,24 @@ class PersistentFIFOCache:
             return
         self._sqlite_path = sqlite_path
         self._sqlite_cache_size_kb = sqlite_cache_size_kb
-        await asyncio.to_thread(self._open_db)
+        try:
+            await asyncio.to_thread(self._open_db)
+        except (OSError, sqlite3.Error) as exc:
+            # Most commonly: cache_dir isn't writable (container without a
+            # writable HOME, hardened systemd unit, read-only filesystem),
+            # the disk is full, or the existing DB file is corrupted. Log
+            # and fall through to memory-only so we don't take the bundler
+            # down for a non-load-bearing optimization.
+            logger.warning(
+                "cache %s: disk tier disabled (%s: %s); running memory-only. "
+                "Set --cache_dir to a writable location, "
+                "--disable_persistent_cache to silence, or "
+                "--clear_cache to wipe a corrupted DB.",
+                self.name, type(exc).__name__, exc,
+            )
+            self._sqlite_path = None
+            self._started = True
+            return
         # Preload the freshest entries from disk so the first batch of RPCs
         # after a restart get hot hits instead of falling through to disk.
         await asyncio.to_thread(self._warm_memory_from_disk)
@@ -276,47 +298,63 @@ class PersistentFIFOCache:
 
     def _open_db(self) -> None:
         assert self._sqlite_path is not None
-        self._sqlite_path.parent.mkdir(parents=True, exist_ok=True)
-        # isolation_level=None puts us in autocommit mode; transactions are
-        # managed explicitly via BEGIN/COMMIT.
-        self._write_conn = sqlite3.connect(
-            str(self._sqlite_path),
-            check_same_thread=False,
-            isolation_level=None,
-        )
-        self._read_conn = sqlite3.connect(
-            str(self._sqlite_path),
-            check_same_thread=False,
-            isolation_level=None,
-        )
-        for conn in (self._write_conn, self._read_conn):
-            # PRAGMAs are per-connection; both conns need them.
-            conn.execute("PRAGMA journal_mode = WAL")
-            conn.execute("PRAGMA synchronous  = NORMAL")
-            conn.execute("PRAGMA temp_store   = MEMORY")
-            conn.execute(f"PRAGMA cache_size  = -{self._sqlite_cache_size_kb}")
-            conn.execute("PRAGMA mmap_size    = 67108864")  # 64 MB virtual
+        try:
+            self._sqlite_path.parent.mkdir(parents=True, exist_ok=True)
+            # isolation_level=None puts us in autocommit mode; transactions
+            # are managed explicitly via BEGIN/COMMIT.
+            self._write_conn = sqlite3.connect(
+                str(self._sqlite_path),
+                check_same_thread=False,
+                isolation_level=None,
+            )
+            self._read_conn = sqlite3.connect(
+                str(self._sqlite_path),
+                check_same_thread=False,
+                isolation_level=None,
+            )
+            for conn in (self._write_conn, self._read_conn):
+                # PRAGMAs are per-connection; both conns need them.
+                conn.execute("PRAGMA journal_mode = WAL")
+                conn.execute("PRAGMA synchronous  = NORMAL")
+                conn.execute("PRAGMA temp_store   = MEMORY")
+                conn.execute(
+                    f"PRAGMA cache_size  = -{self._sqlite_cache_size_kb}",
+                )
+                conn.execute("PRAGMA mmap_size    = 67108864")  # 64 MB virtual
 
-        self._write_conn.executescript(
-            f"""
-            CREATE TABLE IF NOT EXISTS {self.name} (
-                key   TEXT    PRIMARY KEY,
-                value BLOB    NOT NULL,
-                seq   INTEGER NOT NULL
-            );
-            CREATE INDEX IF NOT EXISTS {self.name}_seq
-                ON {self.name} (seq);
-            CREATE TABLE IF NOT EXISTS cache_meta (
-                table_name TEXT PRIMARY KEY,
-                next_seq   INTEGER NOT NULL
-            );
-            """
-        )
-        row = self._write_conn.execute(
-            "SELECT next_seq FROM cache_meta WHERE table_name = ?",
-            (self.name,),
-        ).fetchone()
-        self._next_seq = row[0] if row else 0
+            self._write_conn.executescript(
+                f"""
+                CREATE TABLE IF NOT EXISTS {self.name} (
+                    key   TEXT    PRIMARY KEY,
+                    value BLOB    NOT NULL,
+                    seq   INTEGER NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS {self.name}_seq
+                    ON {self.name} (seq);
+                CREATE TABLE IF NOT EXISTS cache_meta (
+                    table_name TEXT PRIMARY KEY,
+                    next_seq   INTEGER NOT NULL
+                );
+                """
+            )
+            row = self._write_conn.execute(
+                "SELECT next_seq FROM cache_meta WHERE table_name = ?",
+                (self.name,),
+            ).fetchone()
+            self._next_seq = row[0] if row else 0
+        except Exception:
+            # Roll back any partial state so ``start``'s soft-fail path
+            # doesn't see a half-open cache. Best-effort close — we're
+            # about to re-raise, the warning will log the real cause.
+            for conn_attr in ("_write_conn", "_read_conn"):
+                conn = getattr(self, conn_attr, None)
+                if conn is not None:
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
+                    setattr(self, conn_attr, None)
+            raise
 
     def _close_conns(self) -> None:
         try:

--- a/voltaire_bundler/utils/cache.py
+++ b/voltaire_bundler/utils/cache.py
@@ -1,15 +1,16 @@
 """
-In-memory cache wrapper used by the bundler RPC layer.
+In-memory FIFO cache wrapper used by the bundler RPC layer.
 
-Phase 1 of the caching refactor: this class wraps the previous module-level
-``dict`` caches behind a small ``get/set/delete`` interface so subsequent
-phases can swap the storage layer (per-entry FIFO eviction, on-disk
-persistence) without changing call sites.
+Strict FIFO eviction: ``set`` of a new key past capacity drops the single
+oldest entry. ``set`` of an existing key updates the value in place and
+does NOT refresh insertion order — older entries don't get a second life
+just because they were re-written.
 
-Eviction matches the legacy behavior exactly: when the underlying dict
-grows past ``capacity`` entries on insert, the whole dict is replaced with
-an empty one. Per-entry FIFO eviction lands in phase 2.
+The class exposes a small ``get/set/delete`` interface so the storage
+layer can be swapped in later phases (on-disk SQLite tier) without
+touching call sites.
 """
+from collections import OrderedDict
 from typing import Any
 
 
@@ -17,17 +18,19 @@ class InMemoryFIFOCache:
     def __init__(self, name: str, capacity: int = 10_000) -> None:
         self.name = name
         self.capacity = capacity
-        self._data: dict[str, Any] = {}
+        self._data: OrderedDict[str, Any] = OrderedDict()
 
     def get(self, key: str) -> Any | None:
+        # Pure FIFO: reads do not promote — order is fixed at insertion time.
         return self._data.get(key)
 
     def set(self, key: str, value: Any) -> None:
-        # Preserve the legacy "drop everything when full" policy until phase 2
-        # swaps it for OrderedDict.popitem(last=False).
-        if len(self._data) > self.capacity:
-            self._data = {}
+        # OrderedDict preserves the existing position on overwrite, which is
+        # the strict-FIFO behavior we want. Only new keys grow the dict and
+        # can trigger eviction.
         self._data[key] = value
+        if len(self._data) > self.capacity:
+            self._data.popitem(last=False)
 
     def delete(self, key: str) -> None:
         self._data.pop(key, None)


### PR DESCRIPTION
 ## Summary

  Adds a tiered RPC-result cache (in-memory FIFO + optional SQLite cold tier) for the four read-heavy paths behind `eth_getUserOperationByHash` and `eth_getUserOperationReceipt`,
  hardens those paths against slow/misbehaving RPC nodes, and flips two operational defaults.

  ## What's new

  ### Tiered RPC-result cache (`voltaire_bundler/utils/cache.py`)

  A new `PersistentFIFOCache` backs four caches:

  | Cache | Purpose | Trimmed shape |
  |---|---|---|
  | `user_operation_seen_cache` | `userOpHash → validated_at_block_hex` (narrows eth_getLogs range) | n/a (single string) |
  | `user_operation_logs_cache` | `userOpHash → eth_getLogs result` | n/a (logs list) |
  | `transactions_cache` | `txHash → eth_getTransactionByHash` | only `{blockHash, blockNumber, input}` |
  | `transaction_receipts_cache` | `txHash → eth_getTransactionReceipt` (new — wasn't cached before this PR) | 13-field whitelist |

  - **Hot tier**: `OrderedDict`, strict FIFO eviction (`popitem(last=False)` on overflow), default `memory_capacity=10_000` per cache.
  - **Cold tier**: per-cache SQLite file at `{cache_dir}/{name}.sqlite`. WAL mode, `synchronous=NORMAL`, 8 MB page cache, 64 MB mmap. Default `disk_capacity=500_000` per cache.
  - **Writes are off the RPC path**: `set()` does a dict insert plus an `asyncio.Queue.put_nowait()`. A background writer task drains the queue, batches up to 100 writes per SQLite
  transaction, and runs via `asyncio.to_thread` so the event loop never blocks on disk.
  - **Reads memory first, disk fallback** via `asyncio.to_thread`. Disk hits get promoted into memory. A bulk `get_many` collapses the seen-cache fan-out (4 entrypoint versions) into
  one combined `SELECT … WHERE key IN (…)`.
  - **Warm-on-start**: at boot each cache preloads the freshest `memory_capacity` rows from disk so the first RPC requests after a restart hit memory, not disk.
  - **One-shot eviction at writer-task start** prunes any disk overage accumulated across previous sessions.
  - **Soft-fail**: if the SQLite file can't be opened (unwritable dir, full disk, corruption, chain-id-mismatch), the cache logs a warning pointing at the right knob and falls through
   to memory-only — bundler still runs.
  - **Multi-bundler safe**: `PRAGMA busy_timeout = 5000` + `BEGIN IMMEDIATE` lets multiple same-chain bundlers share one SQLite file via WAL serialization. (Memory tiers per-process
  are independent; safe because all cached values are deterministic given the key.)

  ### RPC-lookup hardening

  `get_user_operation_logs_for_block_range`, `get_transaction_by_hash`, and `get_transaction_receipt` are now wrapped in `asyncio.wait_for(timeout=ETH_RPC_LOOKUP_TIMEOUT_S=2.0)` with
  a broad `except Exception: return None`. Previously the shared RPC helper could retry up to 60×60 s, stalling a single lookup for minutes. Now any timeout / network error /
  non-standard response degrades quickly to a "miss" and lets the caller refetch later.

  `eth_getLogs` with `fromBlock="earliest"` (the case where many nodes time out or return invalid responses) now:
  1. Probes `eth_blockNumber` for `latest`.
  2. Tries `eth_getLogs(from=latest-5000, to=latest)` — covers the typical "client polling a freshly submitted userop" pattern.
  3. Only on miss falls through to the full `"earliest"` scan.

  ### Monitor-side cache warmup

  When the bundler's monitor sweep confirms a userop's inclusion via `eth_getLogs`, it now schedules `_warm_inclusion_caches` as a background `asyncio.create_task`. The log entry's
  `transactionHash` is enough to populate `transactions_cache` and `transaction_receipts_cache` ahead of the first client poll, so subsequent RPC handlers serve both lookups from
  cache instead of issuing two more chain RPCs.

  ## Default changes (worth surfacing in release notes)

  - **Persistent cache is on by default.** Writes `~/.voltaire/cache/<chain_id>/{name}.sqlite`. If the directory isn't writable, falls back to memory-only with a warning. Use
  `--disable_persistent_cache` to opt out.
  - **P2P is off by default.** Flipped from the previous "on" default. Use `--disable_p2p false` (or `VOLTAIRE_DISABLE_P2P=false`) to re-enable.

  ## New CLI / env knobs

  | Flag | Env | Default | Notes |
  |---|---|---|---|
  | `--disable_persistent_cache` | `VOLTAIRE_DISABLE_PERSISTENT_CACHE` | `false` | Memory-only mode |
  | `--cache_dir` | `VOLTAIRE_CACHE_DIR` | `~/.voltaire/cache/<chain_id>` | SQLite file location |
  | `--clear_cache` | `VOLTAIRE_CLEAR_CACHE` | `false` | One-shot `shutil.rmtree(cache_dir)` before start |
  | `--cache_memory_size` | `VOLTAIRE_CACHE_MEMORY_SIZE` | `1.0` | Float multiplier on every cache's memory cap |
  | `--cache_disk_size` | `VOLTAIRE_CACHE_DISK_SIZE` | `1.0` | Float multiplier on every cache's disk cap |

  ## Bug fixes folded in along the way

  - Removed unused `from math import e`.
  - Logs-cache eviction was previously broken (`logs_cache = {}` rebound a local instead of evicting the outer dict); the wrapper class fixes it.
  - Trimmed `transactions_cache` entries to the three fields callers actually read (`blockHash`, `blockNumber`, `input`), saving ~30–50% per row.
  - New `transaction_receipts_cache` covers `eth_getTransactionReceipt`, which was previously not cached at any layer.

  ## Implementation notes worth knowing

  - `aclose_all()` in `main.py:finally` only fires on a clean TaskGroup exit. SIGTERM/SIGINT goes through `immediate_exit`, which stops the loop and raises `SystemExit` — so the queue
   drain doesn't run. That's intentional: the queue tail is <1 ms of writes in typical operation, all derivable from chain state. A synchronous drain on SIGTERM would freeze the RPC
  server for up to a few seconds. Documented in `main.py:159-170`.
  - `ETH_RPC_LOOKUP_TIMEOUT_S = 2.0` is a module-level constant, not yet a CLI knob. Operators on a slow remote RPC may need to bump it. Promote to a flag if more than one deployment
  hits this.

  ## Test plan

  - [ ] Bundler starts with default flags, creates `~/.voltaire/cache/<chain_id>/` and four SQLite files
  - [ ] Bundler starts under `--disable_persistent_cache`, no files created
  - [ ] Bundler starts pointed at a read-only `--cache_dir`, logs a warning and runs memory-only
  - [ ] `eth_getUserOperationByHash` hits cache on the second call for a userop we just submitted
  - [ ] Restart bundler, hit `eth_getUserOperationByHash` for an old userop — served from disk tier (warm-on-start)
  - [ ] Submit a bundle, confirm inclusion — verify `eth_getUserOperationReceipt` for that userop returns instantly (monitor-warmed cache)
  - [ ] Two bundler processes on the same `--cache_dir` and chain — both run without WAL contention errors
  - [ ] Slow RPC node returns errors / hangs — `eth_getUserOperationByHash` returns null after ~2 s instead of stalling
  - [ ] `--clear_cache` wipes the directory
  - [ ] `--cache_memory_size 2.0` doubles the memory caps (verifiable via `cache._memory` introspection)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent FIFO caches for transactions, receipts and user-operation logs to reduce RPCs and speed lookups across restarts.
  * New CLI cache flags: --disable_persistent_cache, --cache_dir, --clear_cache, --cache_memory_size, --cache_disk_size; caches start/stop cleanly on launch/exit.
  * Automatic background cache warming for included transactions and a persistent "seen" cache to avoid redundant validations.
* **Behavior Changes**
  * CLI boolean parsing tightened (only "true" accepted) and --disable_p2p defaults to true (opt-in via env flag).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/voltaire/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->