### PR TITLE
refactor: flip persistent cache CLI to --enable_persistent_cache, off by default

### DIFF
--- a/voltaire_bundler/cli_manager.py
+++ b/voltaire_bundler/cli_manager.py
@@ -87,10 +87,10 @@ class InitData:
     min_stake: int
     min_unstake_delay: int
     bundle_gas_estimation_multiplier: float
-    # RPC-result caches are mirrored to SQLite files under ``cache_dir`` so
-    # they survive bundler restarts. Set ``disable_persistent_cache`` to opt
-    # into memory-only mode.
-    disable_persistent_cache: bool
+    # RPC-result caches are memory-only by default. Set
+    # ``enable_persistent_cache`` to mirror them to SQLite files under
+    # ``cache_dir`` so they survive bundler restarts.
+    enable_persistent_cache: bool
     cache_dir: str
     # When True, the cache_dir is wiped at startup. One-shot flag for
     # discarding a corrupted or stale cache.
@@ -521,17 +521,17 @@ def initialize_argument_parser() -> ArgumentParser:
     )
 
     parser.add_argument(
-        "--disable_persistent_cache",
+        "--enable_persistent_cache",
         type=str_to_bool,
         help=(
-            "Opt into memory-only RPC-result caches. By default the caches "
-            "(logs, transactions, receipts, seen) are mirrored to SQLite "
-            "files under --cache_dir so they survive a bundler restart."
+            "Mirror the RPC-result caches (logs, transactions, receipts, "
+            "seen) to SQLite files under --cache_dir so they survive a "
+            "bundler restart. Off by default; caches run memory-only."
         ),
         nargs="?",
         const=True,
         default=_get_env_or_default(
-            "VOLTAIRE_DISABLE_PERSISTENT_CACHE", False,
+            "VOLTAIRE_ENABLE_PERSISTENT_CACHE", False,
             lambda v: v.lower() == "true",
         ),
     )
@@ -541,8 +541,8 @@ def initialize_argument_parser() -> ArgumentParser:
         type=str,
         help=(
             "Directory holding persistent-cache SQLite files. Defaults to "
-            "~/.voltaire/cache/<chain_id>. Ignored when "
-            "--disable_persistent_cache is set."
+            "~/.voltaire/cache/<chain_id>. Ignored unless "
+            "--enable_persistent_cache is set."
         ),
         nargs="?",
         const="",
@@ -555,7 +555,7 @@ def initialize_argument_parser() -> ArgumentParser:
         help=(
             "Wipe --cache_dir before startup. One-shot flag; useful for "
             "discarding a stale or corrupted cache without manually "
-            "deleting files. Ignored when --disable_persistent_cache is set."
+            "deleting files. Ignored unless --enable_persistent_cache is set."
         ),
         nargs="?",
         const=True,
@@ -1091,7 +1091,7 @@ async def get_init_data(args: Namespace) -> InitData:
         args.min_stake,
         args.min_unstake_delay,
         args.bundle_gas_estimation_multiplier,
-        args.disable_persistent_cache,
+        args.enable_persistent_cache,
         args.cache_dir,
         args.clear_cache,
         args.cache_memory_size,

--- a/voltaire_bundler/main.py
+++ b/voltaire_bundler/main.py
@@ -66,12 +66,10 @@ async def main(cmd_args=sys.argv[1:], loop=None) -> None:
         disk_mult=init_data.cache_disk_size,
     )
 
-    # Start the RPC-result caches. By default each cache opens a SQLite file
-    # under cache_dir and resumes from any prior state;
-    # --disable_persistent_cache opts into in-memory-only mode.
-    if init_data.disable_persistent_cache:
-        await PersistentFIFOCache.start_all(cache_dir=None)
-    else:
+    # Start the RPC-result caches. By default the caches run memory-only;
+    # --enable_persistent_cache opts into mirroring each cache to a SQLite
+    # file under cache_dir so state survives a restart.
+    if init_data.enable_persistent_cache:
         cache_dir = (
             Path(init_data.cache_dir).expanduser()
             if init_data.cache_dir
@@ -81,6 +79,8 @@ async def main(cmd_args=sys.argv[1:], loop=None) -> None:
             logging.info("clearing persistent cache at %s", cache_dir)
             shutil.rmtree(cache_dir)
         await PersistentFIFOCache.start_all(cache_dir=cache_dir)
+    else:
+        await PersistentFIFOCache.start_all(cache_dir=None)
 
     # Synchronous part is free; the follow-up disk-row totals run in a
     # background task so the COUNT(*) work doesn't extend startup.

--- a/voltaire_bundler/utils/cache.py
+++ b/voltaire_bundler/utils/cache.py
@@ -154,8 +154,8 @@ class PersistentFIFOCache:
             # down for a non-load-bearing optimization.
             logger.warning(
                 "cache %s: disk tier disabled (%s: %s); running memory-only. "
-                "Set --cache_dir to a writable location, "
-                "--disable_persistent_cache to silence, or "
+                "Set --cache_dir to a writable location, drop "
+                "--enable_persistent_cache to silence, or "
                 "--clear_cache to wipe a corrupted DB.",
                 self.name, type(exc).__name__, exc,
             )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Persistent caching is now opt-in. Users must explicitly enable it with `--enable_persistent_cache` to use disk-based caching. By default, the tool uses in-memory caching only. Cache-related configuration options are only available when persistent caching is enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/voltaire/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->