### PR TITLE
feat: accept per-entrypoint bundler secrets via --bundler_secret

### DIFF
--- a/voltaire_bundler/bundle/bundle_manager.py
+++ b/voltaire_bundler/bundle/bundle_manager.py
@@ -61,8 +61,10 @@ async def _warm_inclusion_caches(
 class BundlerManager:
     ethereum_node_urls: list[str]
     bundle_node_urls: list[str]
-    bundler_private_key: str
-    bundler_address: Address
+    # (address, private_key) per entrypoint label ("v6", "v7", "v8", "v9").
+    # Operators may set one EOA for all four (the default) or a distinct EOA
+    # per entrypoint via comma-separated --bundler_secret.
+    bundler_secrets_per_ep: dict[str, tuple[Address, str]]
     local_mempool_manager_v6: LocalMempoolManagerV6 | None
     local_mempool_manager_v7: LocalMempoolManagerV7
     local_mempool_manager_v8: LocalMempoolManagerV8
@@ -96,8 +98,7 @@ class BundlerManager:
         local_mempool_manager_v9: LocalMempoolManagerV9,
         ethereum_node_urls: list[str],
         bundle_node_urls: list[str],
-        bundler_private_key: str,
-        bundler_address: Address,
+        bundler_secrets_per_ep: dict[str, tuple[Address, str]],
         chain_id: int,
         is_legacy_mode: bool,
         conditional_rpc: ConditionalRpc | None,
@@ -112,8 +113,7 @@ class BundlerManager:
         self.local_mempool_manager_v9 = local_mempool_manager_v9
         self.ethereum_node_urls = ethereum_node_urls
         self.bundle_node_urls = bundle_node_urls
-        self.bundler_private_key = bundler_private_key
-        self.bundler_address = bundler_address
+        self.bundler_secrets_per_ep = bundler_secrets_per_ep
         self.chain_id = chain_id
         self.is_legacy_mode = is_legacy_mode
         self.conditional_rpc = conditional_rpc
@@ -280,6 +280,23 @@ class BundlerManager:
             self.user_operations_to_monitor_v6 |= copy.deepcopy(
                 user_operations_to_bundle_v6)
 
+    def _secret_for_mempool(
+        self,
+        mempool_manager: (
+            LocalMempoolManagerV9
+            | LocalMempoolManagerV8
+            | LocalMempoolManagerV7
+            | LocalMempoolManagerV6
+        ),
+    ) -> tuple[Address, str]:
+        if isinstance(mempool_manager, LocalMempoolManagerV9):
+            return self.bundler_secrets_per_ep["v9"]
+        if isinstance(mempool_manager, LocalMempoolManagerV8):
+            return self.bundler_secrets_per_ep["v8"]
+        if isinstance(mempool_manager, LocalMempoolManagerV7):
+            return self.bundler_secrets_per_ep["v7"]
+        return self.bundler_secrets_per_ep["v6"]
+
     async def send_bundle(
         self,
         user_operations: list[UserOperationV7V8V9] | list[UserOperationV6],
@@ -290,13 +307,15 @@ class BundlerManager:
         num_of_user_operations = len(user_operations)
         if num_of_user_operations == 0:
             return
+        bundler_address, bundler_private_key = self._secret_for_mempool(
+            mempool_manager)
         logging.info(
             f"Attempting to send bundle with {num_of_user_operations} user operations."
         )
 
         call_data_and_call_gas_limit_op = self.create_bundle_calldata_and_estimate_gas(
             user_operations,
-            self.bundler_address,
+            bundler_address,
             entrypoint,
             highest_verified_at_block
         )
@@ -308,7 +327,7 @@ class BundlerManager:
         nonce_op = send_rpc_request_to_eth_client(
             self.ethereum_node_urls,
             "eth_getTransactionCount",
-            [self.bundler_address, "latest"], None, "result"
+            [bundler_address, "latest"], None, "result"
         )
 
         tasks_arr = [
@@ -393,7 +412,7 @@ class BundlerManager:
         if len(auth_list) == 0:
             txnDict = {
                 "chainId": self.chain_id,
-                "from": self.bundler_address,
+                "from": bundler_address,
                 "to": entrypoint,
                 "nonce": nonce,
                 "gas": gas_estimation_hex,
@@ -414,7 +433,7 @@ class BundlerManager:
                     }
                 )
             sign_store_txn = Account.sign_transaction(
-                txnDict, private_key=self.bundler_private_key
+                txnDict, private_key=bundler_private_key
             )
             raw_transaction = "0x" + sign_store_txn.raw_transaction.hex()
         else:
@@ -428,7 +447,7 @@ class BundlerManager:
                 value_hex="0x",
                 data=call_data,
                 authorization_list=auth_list,
-                eoa_private_key=self.bundler_private_key
+                eoa_private_key=bundler_private_key
             )
 
         if self.conditional_rpc is not None and merged_storage_map is not None:
@@ -452,7 +471,7 @@ class BundlerManager:
                     raw_transaction,
                     {"fast": True}
                 ],
-                (self.bundler_address, self.bundler_private_key)
+                (bundler_address, bundler_private_key)
             )
         else:
             result = await send_rpc_request_to_eth_client(
@@ -731,13 +750,13 @@ class BundlerManager:
                 if user_operation.eip7702_auth is not None:
                     auth_list.append(user_operation.eip7702_auth)
             call_data = encode_handleops_calldata_v7v8v9(
-                user_operations_list, self.bundler_address
+                user_operations_list, bundler
             )
         else:
             for user_operation in user_operations:
                 user_operations_list.append(user_operation.to_list())
             call_data = encode_handleops_calldata_v6(
-                user_operations_list, self.bundler_address
+                user_operations_list, bundler
             )
 
         bundle_calldata_init_gas = calculate_bundle_calldata_init_gas(call_data)

--- a/voltaire_bundler/cli_manager.py
+++ b/voltaire_bundler/cli_manager.py
@@ -44,8 +44,10 @@ class InitData:
     rpc_port: int
     ethereum_node_urls: list[str]
     bundle_node_urls: list[str]
-    bundler_pk: str
-    bundler_address: Address
+    # (address, private_key) tuples keyed by entrypoint label
+    # ("v6", "v7", "v8", "v9"). When the operator passes a single
+    # --bundler_secret all four entries share the same EOA.
+    bundler_secrets_per_ep: dict[str, tuple[Address, str]]
     chain_id: int
     is_debug: bool
     is_unsafe: bool
@@ -184,7 +186,12 @@ def initialize_argument_parser() -> ArgumentParser:
     group.add_argument(
         "--bundler_secret",
         type=str,
-        help="Bundler private key",
+        help=(
+            "Bundler private key. Pass a single secret to use one EOA for all "
+            "entrypoints, or four comma-separated secrets (in v0.6,v0.7,v0.8,v0.9 "
+            "order) to use a distinct EOA per entrypoint. When --disable_v6 is "
+            "set the v0.6 slot is still required but its EOA is unused."
+        ),
         nargs="?",
         default=_get_env_or_default("VOLTAIRE_BUNDLER_SECRET", None, str),
     )
@@ -776,49 +783,77 @@ def init_logging(args: Namespace):
     logging.getLogger("Voltaire")
 
 
-async def init_bundler_address_and_secret(args: Namespace, ethereum_node_url: str):
-    bundler_address = ""
-    bundler_pk = ""
+ENTRYPOINT_LABELS = ("v6", "v7", "v8", "v9")
 
+
+async def init_bundler_address_and_secret(
+    args: Namespace, ethereum_node_url: str
+) -> dict[str, tuple[Address, str]]:
     if args.keystore_file_path is not None:
+        # Keystore is single-EOA only: the same EOA is reused for every
+        # entrypoint.
         bundler_address, bundler_pk = import_bundler_account(
             args.keystore_file_password, args.keystore_file_path
         )
+        per_ep_secrets = {
+            label: (bundler_address, bundler_pk) for label in ENTRYPOINT_LABELS
+        }
     else:
-        bundler_pk = args.bundler_secret
-        bundler_address = public_address_from_private_key(bundler_pk)
-
-    try:
-        bundler_code_res = await send_rpc_request_to_eth_client_no_retry(
-            ethereum_node_url,
-            "eth_getCode",
-            [bundler_address, "latest"],
-        )
-        if "result" not in bundler_code_res:
+        raw_secrets = [s.strip() for s in args.bundler_secret.split(",")]
+        if len(raw_secrets) == 1:
+            pk = raw_secrets[0]
+            addr = public_address_from_private_key(pk)
+            per_ep_secrets = {label: (addr, pk) for label in ENTRYPOINT_LABELS}
+        elif len(raw_secrets) == 4:
+            per_ep_secrets = {}
+            for label, pk in zip(ENTRYPOINT_LABELS, raw_secrets):
+                addr = public_address_from_private_key(pk)
+                per_ep_secrets[label] = (addr, pk)
+        else:
             logging.critical(
-                f"eth_getCode failed for bundler address {bundler_address}"
+                "--bundler_secret must be either one secret or four "
+                "comma-separated secrets (one per entrypoint in "
+                "v0.6,v0.7,v0.8,v0.9 order); got "
+                f"{len(raw_secrets)}."
             )
             sys.exit(1)
-        else:
-            bundler_code = bundler_code_res["result"]
-            if (len(bundler_code) > 2):
+
+    # Verify each unique EOA address is actually an EOA (no contract code,
+    # no EIP-7702 delegation). De-duplicate first so the single-secret case
+    # only spends one RPC round-trip.
+    unique_addresses = {addr for addr, _ in per_ep_secrets.values()}
+    for bundler_address in unique_addresses:
+        try:
+            bundler_code_res = await send_rpc_request_to_eth_client_no_retry(
+                ethereum_node_url,
+                "eth_getCode",
+                [bundler_address, "latest"],
+            )
+            if "result" not in bundler_code_res:
                 logging.critical(
-                    f"Invalid Eth bundler beneficiary address: {bundler_address}"
-                    " as it should be an eoa without an eip7702 delegation."
+                    f"eth_getCode failed for bundler address {bundler_address}"
                 )
                 sys.exit(1)
-    except (aiohttp.ClientConnectionError, TimeoutError) as e:
-        logging.critical(
-            f"Connection error for Eth node {ethereum_node_url} for eth_getCode: {e}"
-        )
-        sys.exit(1)
-    except Exception:
-        logging.critical(
-            f"Error when connecting to Eth node {ethereum_node_url} for eth_getCode"
-        )
-        sys.exit(1)
+            else:
+                bundler_code = bundler_code_res["result"]
+                if (len(bundler_code) > 2):
+                    logging.critical(
+                        f"Invalid Eth bundler beneficiary address: {bundler_address}"
+                        " as it should be an eoa without an eip7702 delegation."
+                    )
+                    sys.exit(1)
+        except (aiohttp.ClientConnectionError, TimeoutError) as e:
+            logging.critical(
+                f"Connection error for Eth node {ethereum_node_url} for eth_getCode: {e}"
+            )
+            sys.exit(1)
+        except Exception:
+            logging.critical(
+                f"Error when connecting to Eth node {ethereum_node_url} for eth_getCode"
+            )
+            sys.exit(1)
 
-    return bundler_address, bundler_pk
+    return per_ep_secrets
 
 
 def check_if_valid_rpc_url_and_port(rpc_url, rpc_port) -> None:
@@ -938,7 +973,7 @@ async def get_init_data(args: Namespace) -> InitData:
         )
         sys.exit(1)
 
-    bundler_address, bundler_pk = await init_bundler_address_and_secret(
+    bundler_secrets_per_ep = await init_bundler_address_and_secret(
         args, ethereum_node_urls_rearranged[0])
 
     if args.bundle_node_url is None:
@@ -1048,8 +1083,7 @@ async def get_init_data(args: Namespace) -> InitData:
         args.rpc_port,
         ethereum_node_urls,
         bundle_node_urls,
-        bundler_pk,
-        bundler_address,
+        bundler_secrets_per_ep,
         args.chain_id,
         args.debug,
         args.unsafe,

--- a/voltaire_bundler/cli_manager.py
+++ b/voltaire_bundler/cli_manager.py
@@ -800,6 +800,13 @@ async def init_bundler_address_and_secret(
         }
     else:
         raw_secrets = [s.strip() for s in args.bundler_secret.split(",")]
+        if any(s == "" for s in raw_secrets):
+            logging.critical(
+                "--bundler_secret contains an empty entry; provide either one "
+                "secret or four non-empty comma-separated secrets (one per "
+                "entrypoint in v0.6,v0.7,v0.8,v0.9 order)."
+            )
+            sys.exit(1)
         if len(raw_secrets) == 1:
             pk = raw_secrets[0]
             addr = public_address_from_private_key(pk)

--- a/voltaire_bundler/execution_endpoint.py
+++ b/voltaire_bundler/execution_endpoint.py
@@ -96,8 +96,7 @@ class ExecutionEndpoint(Endpoint):
         self,
         ethereum_node_urls: list[str],
         bundle_node_urls: list[str],
-        bundler_private_key: str,
-        bundler_address: Address,
+        bundler_secrets_per_ep: dict[str, tuple[Address, str]],
         chain_id: int,
         is_unsafe: bool,
         is_debug: bool,
@@ -128,10 +127,19 @@ class ExecutionEndpoint(Endpoint):
         self.ethereum_node_urls = ethereum_node_urls
         self.chain_id = chain_id
 
+        bundler_address_v6, _ = bundler_secrets_per_ep["v6"]
+        bundler_address_v7, _ = bundler_secrets_per_ep["v7"]
+        bundler_address_v8, _ = bundler_secrets_per_ep["v8"]
+        bundler_address_v9, _ = bundler_secrets_per_ep["v9"]
+
+        # The shared v7/v8/v9 user-operation handler only uses ``bundler_address``
+        # as the ``from`` for simulation eth_calls — the balance is state-
+        # overridden to a sentinel value, so any of the three EOAs works.
+        # Pass the v7 address to keep behavior deterministic.
         self.user_operation_handler_v7v8v9 = UserOperationHandlerV7V8V9(
             chain_id,
             ethereum_node_urls,
-            bundler_address,
+            bundler_address_v7,
             is_legacy_mode,
             ethereum_node_eth_get_logs_urls,
             max_verification_gas,
@@ -143,7 +151,7 @@ class ExecutionEndpoint(Endpoint):
         self.local_mempool_manager_v9 = LocalMempoolManagerV9(
             self.user_operation_handler_v7v8v9,
             ethereum_node_urls,
-            bundler_address,
+            bundler_address_v9,
             chain_id,
             is_unsafe,
             enforce_gas_price_tolerance,
@@ -159,7 +167,7 @@ class ExecutionEndpoint(Endpoint):
         self.local_mempool_manager_v8 = LocalMempoolManagerV8(
             self.user_operation_handler_v7v8v9,
             ethereum_node_urls,
-            bundler_address,
+            bundler_address_v8,
             chain_id,
             is_unsafe,
             enforce_gas_price_tolerance,
@@ -175,7 +183,7 @@ class ExecutionEndpoint(Endpoint):
         self.local_mempool_manager_v7 = LocalMempoolManagerV7(
             self.user_operation_handler_v7v8v9,
             ethereum_node_urls,
-            bundler_address,
+            bundler_address_v7,
             chain_id,
             is_unsafe,
             enforce_gas_price_tolerance,
@@ -195,7 +203,7 @@ class ExecutionEndpoint(Endpoint):
             self.user_operation_handler_v6 = UserOperationHandlerV6(
                 chain_id,
                 ethereum_node_urls,
-                bundler_address,
+                bundler_address_v6,
                 is_legacy_mode,
                 ethereum_node_eth_get_logs_urls,
                 max_verification_gas,
@@ -207,7 +215,7 @@ class ExecutionEndpoint(Endpoint):
             self.local_mempool_manager_v6 = LocalMempoolManagerV6(
                 self.user_operation_handler_v6,
                 ethereum_node_urls,
-                bundler_address,
+                bundler_address_v6,
                 chain_id,
                 is_unsafe,
                 enforce_gas_price_tolerance,
@@ -227,8 +235,7 @@ class ExecutionEndpoint(Endpoint):
             self.local_mempool_manager_v9,
             ethereum_node_urls,
             bundle_node_urls,
-            bundler_private_key,
-            bundler_address,
+            bundler_secrets_per_ep,
             chain_id,
             is_legacy_mode,
             conditional_rpc,

--- a/voltaire_bundler/main.py
+++ b/voltaire_bundler/main.py
@@ -91,8 +91,7 @@ async def main(cmd_args=sys.argv[1:], loop=None) -> None:
             execution_endpoint: ExecutionEndpoint = ExecutionEndpoint(
                 init_data.ethereum_node_urls,
                 init_data.bundle_node_urls,
-                init_data.bundler_pk,
-                init_data.bundler_address,
+                init_data.bundler_secrets_per_ep,
                 init_data.chain_id,
                 init_data.is_unsafe,
                 init_data.is_debug,
@@ -127,11 +126,19 @@ async def main(cmd_args=sys.argv[1:], loop=None) -> None:
             if init_data.ethereum_node_urls != init_data.ethereum_node_eth_get_logs_urls:
                 node_urls_to_check += init_data.ethereum_node_eth_get_logs_urls
 
+            # When --disable_v6 is set the v6 EOA is parsed but never used,
+            # so don't burn an eth_getBalance call on it.
+            labels_to_check = ("v7", "v8", "v9") if init_data.disable_v6 \
+                else ("v6", "v7", "v8", "v9")
+            bundler_addresses_to_check = sorted({
+                init_data.bundler_secrets_per_ep[label][0]
+                for label in labels_to_check
+            })
             task_group.create_task(
                 run_rpc_http_server(
                     node_urls_to_check=node_urls_to_check,
                     target_chain_id_hex=hex(init_data.chain_id),
-                    bundler=init_data.bundler_address,
+                    bundlers=bundler_addresses_to_check,
                     min_balance=init_data.min_bundler_balance,
                     host=init_data.rpc_url,
                     rpc_cors_domain=init_data.rpc_cors_domain,
@@ -150,7 +157,7 @@ async def main(cmd_args=sys.argv[1:], loop=None) -> None:
                         periodic_health_check_cron_job(
                             node_urls_to_check=node_urls_to_check,
                             target_chain_id_hex=hex(init_data.chain_id),
-                            bundler=init_data.bundler_address,
+                            bundlers=bundler_addresses_to_check,
                             min_balance=init_data.min_bundler_balance,
                             interval=init_data.health_check_interval
                         )

--- a/voltaire_bundler/rpc/health.py
+++ b/voltaire_bundler/rpc/health.py
@@ -9,7 +9,7 @@ from voltaire_bundler.utils.eth_client_utils import \
 async def periodic_health_check_cron_job(
     node_urls_to_check: list[str],
     target_chain_id_hex: str,
-    bundler: Address,
+    bundlers: list[Address],
     min_balance: int,
     interval: int
 ):
@@ -17,7 +17,7 @@ async def periodic_health_check_cron_job(
         await periodic_health_check(
             node_urls_to_check,
             target_chain_id_hex,
-            bundler,
+            bundlers,
             min_balance,
         )
         await asyncio.sleep(interval)
@@ -26,19 +26,35 @@ async def periodic_health_check_cron_job(
 async def periodic_health_check(
     node_urls_to_check: list[str],
     target_chain_id_hex: str,
-    bundler: Address,
+    bundlers: list[Address],
     min_balance: int,
 ):
     nodes_success, _ = await check_nodes_health(
         node_urls_to_check, target_chain_id_hex)
     if nodes_success:
-        await check_bundler_balance(
-            node_urls_to_check[0], bundler, min_balance)
+        await check_bundlers_balance(
+            node_urls_to_check[0], bundlers, min_balance)
 
 
-async def check_bundler_balance(
+async def check_bundlers_balance(
+    ethereum_node_url: str, bundlers: list[Address], min_balance: int
+) -> tuple[bool, dict[str, dict[str, str]]]:
+    """Check that every distinct bundler EOA holds at least ``min_balance``.
+    Returns aggregate success plus a per-address result map so the /health
+    endpoint can surface which EOA is short."""
+    per_bundler: dict[str, dict[str, str]] = {}
+    all_ok = True
+    for bundler in bundlers:
+        ok, result = await _check_single_bundler_balance(
+            ethereum_node_url, bundler, min_balance)
+        per_bundler[bundler] = result
+        all_ok = all_ok and ok
+    return all_ok, per_bundler
+
+
+async def _check_single_bundler_balance(
     ethereum_node_url: str, bundler: Address, min_balance: int
-) -> tuple[bool, dict]:
+) -> tuple[bool, dict[str, str]]:
     try:
         bundler_balance_res = await send_rpc_request_to_eth_client_no_retry(
             ethereum_node_url,

--- a/voltaire_bundler/rpc/rpc_http_server.py
+++ b/voltaire_bundler/rpc/rpc_http_server.py
@@ -13,7 +13,7 @@ from prometheus_client import Summary
 from voltaire_bundler.bundle.exceptions import (ExecutionException,
                                                  ValidationException)
 from voltaire_bundler.event_bus_manager.endpoint import Client, RequestEvent
-from voltaire_bundler.rpc.health import check_bundler_balance, check_nodes_health
+from voltaire_bundler.rpc.health import check_bundlers_balance, check_nodes_health
 from voltaire_bundler.rpc.jsonrpc import \
     RPCFault, RPCInvalidMethodParams, validate_and_load_json_rpc_request
 from voltaire_bundler.custom_types import Address
@@ -346,7 +346,7 @@ async def handle(request: web.Request) -> web.Response:
 async def check_health(
     node_urls_to_check: list[str],
     target_chain_id_hex: str,
-    bundler: Address,
+    bundlers: list[Address],
     min_balance: int,
     _: web.Request
 ) -> web.Response:
@@ -358,8 +358,8 @@ async def check_health(
     results = dict()
     results["nodes_status"] = nodes_results
     if nodes_success:
-        bundler_balance_success, bundler_balance_results = await check_bundler_balance(
-            node_urls_to_check[0], bundler, min_balance)
+        bundler_balance_success, bundler_balance_results = await check_bundlers_balance(
+            node_urls_to_check[0], bundlers, min_balance)
         results["bundler_balance"] = bundler_balance_results
         all_ok = nodes_success and bundler_balance_success
 
@@ -374,7 +374,7 @@ async def check_health(
 async def run_rpc_http_server(
     node_urls_to_check: list[str],
     target_chain_id_hex: str,
-    bundler: Address,
+    bundlers: list[Address],
     min_balance: int,
     host: str = "localhost",
     rpc_cors_domain: str = "*",
@@ -405,7 +405,7 @@ async def run_rpc_http_server(
             check_health,
             node_urls_to_check,
             target_chain_id_hex,
-            bundler,
+            bundlers,
             min_balance
         )
     )


### PR DESCRIPTION
Operators can now pass four comma-separated secrets (v0.6,v0.7,v0.8,v0.9 order) to give each entrypoint its own EOA. Passing one secret keeps the previous single-EOA behavior. Per-EP signing avoids the shared-nonce race in the existing parallel send_bundle path, so bundles for different entrypoints can land in the same block. /health and the periodic balance check now sweep every distinct bundler EOA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-entrypoint bundler support: use distinct bundler EOAs/secrets for v0.6, v0.7, v0.8, v0.9.
  * CLI accepts either one secret (applies to all) or four comma-separated secrets for version-specific bundlers.

* **Improvements**
  * Health checks and RPC endpoints now handle multiple bundlers and report per-bundler balance/status.
  * CLI validation ensures supplied bundler EOAs are externally owned (not contracts).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/voltaire/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->