### PR TITLE
feat: add --enable_banning CLI flag, disabled by default

### DIFF
--- a/voltaire_bundler/cli_manager.py
+++ b/voltaire_bundler/cli_manager.py
@@ -99,6 +99,10 @@ class InitData:
     # built-in defaults; bump up on hosts with more RAM/disk headroom.
     cache_memory_size: float
     cache_disk_size: float
+    # When False (the default), reputation-driven bans are not enforced:
+    # the bundler logs that an entity *would* have been banned and resets
+    # its accumulated reputation score instead.
+    enable_banning: bool
 
 
 def address(ep: str):
@@ -675,6 +679,23 @@ def initialize_argument_parser() -> ArgumentParser:
     )
 
     parser.add_argument(
+        "--enable_banning",
+        type=str_to_bool,
+        help=(
+            "Enforce reputation-driven bans of entities that fail validation "
+            "or exceed the inclusion-rate threshold. Off by default; when "
+            "off the bundler logs that an entity would have been banned and "
+            "resets its reputation score instead of marking it BANNED."
+        ),
+        nargs="?",
+        const=True,
+        default=_get_env_or_default(
+            "VOLTAIRE_ENABLE_BANNING", False,
+            lambda v: v.lower() == "true",
+        ),
+    )
+
+    parser.add_argument(
         "--eip7702",
         type=str_to_bool,
         help="enable eip7702 auth",
@@ -1096,6 +1117,7 @@ async def get_init_data(args: Namespace) -> InitData:
         args.clear_cache,
         args.cache_memory_size,
         args.cache_disk_size,
+        args.enable_banning,
     )
 
     if args.verbose:

--- a/voltaire_bundler/execution_endpoint.py
+++ b/voltaire_bundler/execution_endpoint.py
@@ -123,6 +123,7 @@ class ExecutionEndpoint(Endpoint):
         min_stake: int,
         min_unstake_delay: int,
         bundle_gas_estimation_multiplier: float,
+        enable_banning: bool,
     ):
         super().__init__("bundler_endpoint")
         self.ethereum_node_urls = ethereum_node_urls
@@ -153,7 +154,8 @@ class ExecutionEndpoint(Endpoint):
             reputation_whitelist,
             reputation_blacklist,
             min_stake,
-            min_unstake_delay
+            min_unstake_delay,
+            enable_banning,
         )
 
         self.local_mempool_manager_v8 = LocalMempoolManagerV8(
@@ -169,7 +171,8 @@ class ExecutionEndpoint(Endpoint):
             reputation_whitelist,
             reputation_blacklist,
             min_stake,
-            min_unstake_delay
+            min_unstake_delay,
+            enable_banning,
         )
 
         self.local_mempool_manager_v7 = LocalMempoolManagerV7(
@@ -185,7 +188,8 @@ class ExecutionEndpoint(Endpoint):
             reputation_whitelist,
             reputation_blacklist,
             min_stake,
-            min_unstake_delay
+            min_unstake_delay,
+            enable_banning,
         )
 
         if disable_v6:
@@ -217,7 +221,8 @@ class ExecutionEndpoint(Endpoint):
                 reputation_whitelist,
                 reputation_blacklist,
                 min_stake,
-                min_unstake_delay
+                min_unstake_delay,
+                enable_banning,
             )
 
         self.bundle_manager = BundlerManager(

--- a/voltaire_bundler/main.py
+++ b/voltaire_bundler/main.py
@@ -117,7 +117,8 @@ async def main(cmd_args=sys.argv[1:], loop=None) -> None:
                 init_data.is_eip7702,
                 init_data.min_stake,
                 init_data.min_unstake_delay,
-                init_data.bundle_gas_estimation_multiplier
+                init_data.bundle_gas_estimation_multiplier,
+                init_data.enable_banning,
             )
             task_group.create_task(execution_endpoint.start_execution_endpoint())
 

--- a/voltaire_bundler/mempool/mempool_manager_v6.py
+++ b/voltaire_bundler/mempool/mempool_manager_v6.py
@@ -29,7 +29,8 @@ class LocalMempoolManagerV6(LocalMempoolManager):
         reputation_whitelist: list[str],
         reputation_blacklist: list[str],
         min_stake: int,
-        min_unstake_delay: int
+        min_unstake_delay: int,
+        enable_banning: bool,
     ):
         self.validation_manager = ValidationManagerV6(
             user_operation_handler,
@@ -44,7 +45,7 @@ class LocalMempoolManagerV6(LocalMempoolManager):
         )
         self.user_operation_handler = user_operation_handler
         self.reputation_manager = ReputationManager(
-            reputation_whitelist, reputation_blacklist)
+            reputation_whitelist, reputation_blacklist, enable_banning)
         self.ethereum_node_urls = ethereum_node_urls
         self.bundler_address = bundler_address
         self.chain_id = chain_id

--- a/voltaire_bundler/mempool/mempool_manager_v7.py
+++ b/voltaire_bundler/mempool/mempool_manager_v7.py
@@ -29,7 +29,8 @@ class LocalMempoolManagerV7(LocalMempoolManager):
         reputation_whitelist: list[str],
         reputation_blacklist: list[str],
         min_stake: int,
-        min_unstake_delay: int
+        min_unstake_delay: int,
+        enable_banning: bool,
     ):
         self.validation_manager = ValidationManagerV7V8V9(
             user_operation_handler,
@@ -44,7 +45,7 @@ class LocalMempoolManagerV7(LocalMempoolManager):
         )
         self.user_operation_handler = user_operation_handler
         self.reputation_manager = ReputationManager(
-            reputation_whitelist, reputation_blacklist)
+            reputation_whitelist, reputation_blacklist, enable_banning)
         self.ethereum_node_urls = ethereum_node_urls
         self.bundler_address = bundler_address
         self.chain_id = chain_id

--- a/voltaire_bundler/mempool/mempool_manager_v8.py
+++ b/voltaire_bundler/mempool/mempool_manager_v8.py
@@ -29,7 +29,8 @@ class LocalMempoolManagerV8(LocalMempoolManager):
         reputation_whitelist: list[str],
         reputation_blacklist: list[str],
         min_stake: int,
-        min_unstake_delay: int
+        min_unstake_delay: int,
+        enable_banning: bool,
     ):
         self.validation_manager = ValidationManagerV7V8V9(
             user_operation_handler,
@@ -44,7 +45,7 @@ class LocalMempoolManagerV8(LocalMempoolManager):
         )
         self.user_operation_handler = user_operation_handler
         self.reputation_manager = ReputationManager(
-            reputation_whitelist, reputation_blacklist)
+            reputation_whitelist, reputation_blacklist, enable_banning)
         self.ethereum_node_urls = ethereum_node_urls
         self.bundler_address = bundler_address
         self.chain_id = chain_id

--- a/voltaire_bundler/mempool/mempool_manager_v9.py
+++ b/voltaire_bundler/mempool/mempool_manager_v9.py
@@ -29,7 +29,8 @@ class LocalMempoolManagerV9(LocalMempoolManager):
         reputation_whitelist: list[str],
         reputation_blacklist: list[str],
         min_stake: int,
-        min_unstake_delay: int
+        min_unstake_delay: int,
+        enable_banning: bool,
     ):
         self.validation_manager = ValidationManagerV7V8V9(
             user_operation_handler,
@@ -44,7 +45,7 @@ class LocalMempoolManagerV9(LocalMempoolManager):
         )
         self.user_operation_handler = user_operation_handler
         self.reputation_manager = ReputationManager(
-            reputation_whitelist, reputation_blacklist)
+            reputation_whitelist, reputation_blacklist, enable_banning)
         self.ethereum_node_urls = ethereum_node_urls
         self.bundler_address = bundler_address
         self.chain_id = chain_id

--- a/voltaire_bundler/mempool/reputation_manager.py
+++ b/voltaire_bundler/mempool/reputation_manager.py
@@ -31,7 +31,8 @@ class ReputationManager:
     def __init__(
             self,
             reputation_whitelist: list[str],
-            reputation_blacklist: list[str]
+            reputation_blacklist: list[str],
+            enable_banning: bool = False,
     ) -> None:
         self.entities_reputation = {}
         if reputation_whitelist is not None:
@@ -44,6 +45,7 @@ class ReputationManager:
                 lambda entity: entity.lower(), reputation_blacklist))
         else:
             self.blacklist = []
+        self.enable_banning = enable_banning
         asyncio.ensure_future(self.execute_reputation_cron_job())
 
     async def execute_reputation_cron_job(self) -> None:
@@ -85,6 +87,16 @@ class ReputationManager:
         if self.is_whitelisted(entity_lowercase):
             logging.warning(
                 f"{entity} won't be banned because it is whitelisted.")
+        elif not self.enable_banning:
+            # Banning is disabled by config: log that this entity *would* have
+            # been banned, then drop any accumulated reputation so the entity
+            # starts fresh and the throttle/ban thresholds don't trip again
+            # immediately on the next interaction.
+            logging.warning(
+                f"{entity} should have been banned, but banning is disabled; "
+                "resetting its reputation score."
+            )
+            self.entities_reputation.pop(entity_lowercase, None)
         else:
             self.entities_reputation[entity_lowercase] = ReputationEntry(10000, 0)
 


### PR DESCRIPTION
When banning is disabled, ban_entity logs a warning that the entity would have been banned and resets its reputation score instead of marking it BANNED, so operators can observe reputation hits without evicting traffic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to control whether reputation-driven bans are enforced across the bundler. Users can enable or disable banning via a new CLI flag. When disabled, the system logs what bans would have occurred while clearing reputation scores for a fresh start.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/voltaire/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->