### PR TITLE
feat: add --logs_fallback_recent_window CLI flag

### DIFF
--- a/voltaire_bundler/cli_manager.py
+++ b/voltaire_bundler/cli_manager.py
@@ -105,6 +105,10 @@ class InitData:
     # the bundler logs that an entity *would* have been banned and resets
     # its accumulated reputation score instead.
     enable_banning: bool
+    # Block window for the cheap recent-blocks probe that runs before a
+    # full ``fromBlock="earliest"`` eth_getLogs scan in
+    # eth_getUserOperationByHash/Receipt.
+    logs_fallback_recent_window: int
 
 
 def address(ep: str):
@@ -658,6 +662,22 @@ def initialize_argument_parser() -> ArgumentParser:
     )
 
     parser.add_argument(
+        "--logs_fallback_recent_window",
+        type=unsigned_int,
+        help=(
+            "Block window for the cheap recent-blocks probe that runs "
+            "before a full fromBlock=\"earliest\" eth_getLogs scan in "
+            "eth_getUserOperationByHash/Receipt. The vast majority of "
+            "polling clients hit a userop submitted seconds ago, which "
+            "lives within this window. Defaults to 5000."
+        ),
+        nargs="?",
+        const=5_000,
+        default=_get_env_or_default(
+            "VOLTAIRE_LOGS_FALLBACK_RECENT_WINDOW", 5_000, int),
+    )
+
+    parser.add_argument(
         "--health_check_interval",
         type=int,
         help=(
@@ -1159,6 +1179,7 @@ async def get_init_data(args: Namespace) -> InitData:
         args.cache_memory_size,
         args.cache_disk_size,
         args.enable_banning,
+        args.logs_fallback_recent_window,
     )
 
     if args.verbose:

--- a/voltaire_bundler/cli_manager.py
+++ b/voltaire_bundler/cli_manager.py
@@ -674,7 +674,7 @@ def initialize_argument_parser() -> ArgumentParser:
         nargs="?",
         const=5_000,
         default=_get_env_or_default(
-            "VOLTAIRE_LOGS_FALLBACK_RECENT_WINDOW", 5_000, int),
+            "VOLTAIRE_LOGS_FALLBACK_RECENT_WINDOW", 5_000, unsigned_int),
     )
 
     parser.add_argument(

--- a/voltaire_bundler/execution_endpoint.py
+++ b/voltaire_bundler/execution_endpoint.py
@@ -123,6 +123,7 @@ class ExecutionEndpoint(Endpoint):
         min_unstake_delay: int,
         bundle_gas_estimation_multiplier: float,
         enable_banning: bool,
+        logs_fallback_recent_window: int,
     ):
         super().__init__("bundler_endpoint")
         self.ethereum_node_urls = ethereum_node_urls
@@ -147,6 +148,7 @@ class ExecutionEndpoint(Endpoint):
             max_call_data_gas,
             logs_incremental_range,
             logs_number_of_ranges,
+            logs_fallback_recent_window,
         )
 
         self.local_mempool_manager_v9 = LocalMempoolManagerV9(
@@ -214,6 +216,7 @@ class ExecutionEndpoint(Endpoint):
                 max_call_data_gas,
                 logs_incremental_range,
                 logs_number_of_ranges,
+                logs_fallback_recent_window,
             )
 
             self.local_mempool_manager_v6 = LocalMempoolManagerV6(

--- a/voltaire_bundler/main.py
+++ b/voltaire_bundler/main.py
@@ -118,6 +118,7 @@ async def main(cmd_args=sys.argv[1:], loop=None) -> None:
                 init_data.min_unstake_delay,
                 init_data.bundle_gas_estimation_multiplier,
                 init_data.enable_banning,
+                init_data.logs_fallback_recent_window,
             )
             task_group.create_task(execution_endpoint.start_execution_endpoint())
 

--- a/voltaire_bundler/user_operation/user_operation_handler.py
+++ b/voltaire_bundler/user_operation/user_operation_handler.py
@@ -28,6 +28,7 @@ class UserOperationHandler(ABC):
     gas_manager: GasManager
     logs_incremental_range: int
     logs_number_of_ranges: int
+    logs_fallback_recent_window: int
 
     async def _find_handle_ops_calldata(
         self,
@@ -368,7 +369,8 @@ class UserOperationHandler(ABC):
                     user_operation_hash,
                     entrypoint,
                     hex(earliest_block),
-                    hex(latest_block)
+                    hex(latest_block),
+                    self.logs_fallback_recent_window,
                 )
                 if res is not None:
                     return res
@@ -384,7 +386,8 @@ class UserOperationHandler(ABC):
                 user_operation_hash,
                 entrypoint,
                 earliest_block_hex,
-                "latest"
+                "latest",
+                self.logs_fallback_recent_window,
             )
 
     def get_user_operation_by_hash_from_local_mempool(
@@ -492,6 +495,10 @@ ETH_RPC_LOOKUP_TIMEOUT_S = 2.0
 # are clients polling a userop submitted seconds ago, which lives well
 # within this window — and many nodes either time out or return invalid
 # responses for a full-history eth_getLogs scan.
+#
+# Default size of that probe window when the caller doesn't pass an
+# explicit value. The CLI surfaces this as --logs_fallback_recent_window;
+# handler-driven calls override it with the operator-configured value.
 EARLIEST_FALLBACK_RECENT_WINDOW = 5_000
 
 
@@ -651,6 +658,7 @@ async def get_user_operation_logs_for_block_range(
     entrypoint: str,
     from_block_hex: str,
     to_block_hex: str,
+    earliest_fallback_recent_window: int = EARLIEST_FALLBACK_RECENT_WINDOW,
 ) -> list | None:
     cache_key = f"{entrypoint.lower()}:{user_operation_hash}"
     cached = await user_operation_logs_cache.get(cache_key)
@@ -665,17 +673,17 @@ async def get_user_operation_logs_for_block_range(
         user_operation_logs_cache.delete(cache_key)
 
     # If the caller asked for the whole chain, first probe the last
-    # EARLIEST_FALLBACK_RECENT_WINDOW blocks — that covers the typical
-    # "client polling a freshly submitted userop" pattern at a fraction
-    # of the wide-scan cost. Fall through to the full "earliest" scan
-    # only if the narrow window misses.
+    # ``earliest_fallback_recent_window`` blocks — that covers the
+    # typical "client polling a freshly submitted userop" pattern at a
+    # fraction of the wide-scan cost. Fall through to the full "earliest"
+    # scan only if the narrow window misses.
     if from_block_hex == "earliest":
         latest = await _fetch_latest_block_number(
             ethereum_node_eth_get_logs_urls,
         )
         if latest is not None:
             window_from = hex(
-                max(0, latest - EARLIEST_FALLBACK_RECENT_WINDOW)
+                max(0, latest - earliest_fallback_recent_window)
             )
             result = await _eth_getLogs_once(
                 ethereum_node_eth_get_logs_urls,

--- a/voltaire_bundler/user_operation/user_operation_handler_v6.py
+++ b/voltaire_bundler/user_operation/user_operation_handler_v6.py
@@ -25,6 +25,7 @@ class UserOperationHandlerV6(UserOperationHandler):
         max_call_data_gas: int,
         logs_incremental_range: int,
         logs_number_of_ranges: int,
+        logs_fallback_recent_window: int,
     ):
         self.ethereum_node_urls = ethereum_node_urls
         self.bundler_address = bundler_address
@@ -40,6 +41,7 @@ class UserOperationHandlerV6(UserOperationHandler):
         )
         self.logs_incremental_range = logs_incremental_range
         self.logs_number_of_ranges = logs_number_of_ranges
+        self.logs_fallback_recent_window = logs_fallback_recent_window
 
     async def get_user_operation_by_hash(
         self, user_operation_hash: str,

--- a/voltaire_bundler/user_operation/user_operation_handler_v7v8v9.py
+++ b/voltaire_bundler/user_operation/user_operation_handler_v7v8v9.py
@@ -26,6 +26,7 @@ class UserOperationHandlerV7V8V9(UserOperationHandler):
         max_call_data_gas: int,
         logs_incremental_range: int,
         logs_number_of_ranges: int,
+        logs_fallback_recent_window: int,
     ):
         self.ethereum_node_urls = ethereum_node_urls
         self.bundler_address = bundler_address
@@ -42,6 +43,7 @@ class UserOperationHandlerV7V8V9(UserOperationHandler):
         )
         self.logs_incremental_range = logs_incremental_range
         self.logs_number_of_ranges = logs_number_of_ranges
+        self.logs_fallback_recent_window = logs_fallback_recent_window
 
     async def get_user_operation_by_hash(
         self, user_operation_hash: str,


### PR DESCRIPTION
Surfaces the recent-blocks probe window used before a full fromBlock="earliest" eth_getLogs scan in
eth_getUserOperationByHash/Receipt. Defaults to 5000 to preserve existing behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable `--logs_fallback_recent_window` CLI option and `VOLTAIRE_LOGS_FALLBACK_RECENT_WINDOW` env var (default: 5000) to tune recent-block probing before full log scans.
  * Startup and execution components now honor this setting so log retrieval probes a recent window first, reducing full-scan work and improving performance for recent events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/voltaire/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->