### PR TITLE
fix: clamp eth_getLogs toBlock to chain head in userop log scan

### DIFF
--- a/voltaire_bundler/user_operation/user_operation_handler.py
+++ b/voltaire_bundler/user_operation/user_operation_handler.py
@@ -361,8 +361,21 @@ class UserOperationHandler(ABC):
             for earliest_block in range(earliest_block_number,
                                         latest_block_number + 1,
                                         logs_incremental_range):
-                latest_block = earliest_block + logs_incremental_range
-                if latest_block <= earliest_block:
+                # Clamp toBlock to the chain head. Without this, the final
+                # iteration requests earliest_block + logs_incremental_range,
+                # which overshoots latest_block_number by up to one full
+                # window — a toBlock that isn't on-chain yet. Tolerant nodes
+                # silently clamp it to head; stricter ones (and multi-node
+                # setups where the logs endpoint lags the head read) reject it
+                # with "missing block data", spamming errors and making
+                # eth_getUserOperationReceipt miss freshly included userops.
+                # eth_getLogs is inclusive on both ends, so a [head, head]
+                # window is a valid single-block query and loses no coverage.
+                latest_block = min(
+                    earliest_block + logs_incremental_range,
+                    latest_block_number,
+                )
+                if latest_block < earliest_block:
                     break
                 res = await get_user_operation_logs_for_block_range(
                     self.ethereum_node_eth_get_logs_urls,


### PR DESCRIPTION
## Summary

`eth_getUserOperationReceipt` (and `eth_getUserOperationByHash`) intermittently
logged `eth_getLogs` errors like:

> error code: -1 and error message: missing block data.

…with a `toBlock` past the current chain head, and transiently returned `null`
for userops that were already on-chain.

## Root cause

In `get_user_operation_logs` (`voltaire_bundler/user_operation/user_operation_handler.py`),
the incremental-range scan clamped only the **lower** bound (`earliest_block`)
to the chain head. The per-iteration `toBlock` was computed as
`earliest_block + logs_incremental_range` and never clamped, so the final loop
iteration always requested a window up to one full `logs_incremental_range`
past the head — a `toBlock` that isn't on-chain yet.

- Tolerant nodes (e.g. geth) silently clamp `toBlock` to head, so the bug was invisible there.
- Stricter nodes — and multi-node setups where the logs endpoint lags the head read — reject it with `missing block data` (code `-1`).

It surfaced "sometimes" because the loop returns on the first window that hits;
the overshooting window is only reached when the userop is in the head-adjacent
range (freshly included) or absent — exactly the poll-just-after-inclusion case.

## Fix

Clamp `toBlock` to the chain head and relax the loop guard so the valid
single-block `[head, head]` window still issues its query (`eth_getLogs` is
inclusive on both ends, so no coverage is lost):

```python
latest_block = min(
    earliest_block + logs_incremental_range,
    latest_block_number,
)
if latest_block < earliest_block:
    break
```

The change is on the base UserOperationHandler, so it covers all EntryPoint
versions (v0.6–v0.9) and both eth_getUserOperationReceipt and
eth_getUserOperationByHash.

Impact / scope

- Only affects deployments running with --logs_incremental_range > 0
(VOLTAIRE_LOGS_INCREMENTAL_RANGE). Default config (0) uses the
fromBlock=… toBlock="latest" path and was never exposed.
- No on-chain block coverage is lost; the only behavioral change is that the
head-adjacent window is bounded to the head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced incremental log scanning to properly clamp block ranges to the current chain state, preventing requests for invalid future blocks that could result in missing logs or receipts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->