### PR TITLE
fix: voltaire_feesPerGas IndexError on Arbitrum

### DIFF
--- a/voltaire_bundler/execution_endpoint.py
+++ b/voltaire_bundler/execution_endpoint.py
@@ -821,7 +821,12 @@ class ExecutionEndpoint(Endpoint):
 
         max_fee_per_gas_hex = tasks[0]["result"]
 
-        if self.chain_id == 999 or self.chain_id == 998:  # HyperEVM
+        # HyperEVM and Arbitrum: eth_maxPriorityFeePerGas was skipped above,
+        # so tasks only has one element; default the priority fee to 0.
+        if (
+            self.chain_id == 999 or self.chain_id == 998 or
+            self.chain_id == 42161 or self.chain_id == 421614
+        ):
             max_priority_fee_per_gas_with_buffer = "0x0"
         else:
             max_priority_fee_per_gas_hex = tasks[1]["result"]


### PR DESCRIPTION
Commit c6e924e added Arbitrum (42161, 421614) to the eth_maxPriorityFeePerGas skip list in _event_voltaire_feesPerGas but did not update the matching access guard, so tasks[1] was still read when tasks had only one element. Mirror the skip condition in the priority-fee=0 branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gas fee handling for additional networks, ensuring fee estimates are returned correctly when only one gas-price result is available.
  * For affected chains, the priority fee now defaults to zero instead of relying on a missing secondary result, reducing failed or inconsistent fee calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->