### PR TITLE
Uniform 1 sec gas price cache refresh interval and idle aware cache

### DIFF
--- a/voltaire_bundler/cli_manager.py
+++ b/voltaire_bundler/cli_manager.py
@@ -12,7 +12,7 @@ import aiohttp
 
 from voltaire_bundler.gas.gas_price_cache import (
     GasPriceCache,
-    default_refresh_interval,
+    DEFAULT_REFRESH_INTERVAL_SECONDS,
 )
 from voltaire_bundler.mempool.mempool_info import DEFAULT_MEMPOOL_INFO
 from voltaire_bundler.user_operation import user_operation_handler
@@ -403,10 +403,11 @@ def initialize_argument_parser() -> ArgumentParser:
         type=positive_float,
         help=(
             "seconds between background refreshes of the cached "
-            "eth_gasPrice / eth_maxPriorityFeePerGas values. Defaults to a "
-            "per-chain value roughly matching the chain's block time "
-            "(e.g. 10s on Ethereum mainnet, 2s on L2s, 1s on Arbitrum / "
-            "HyperEVM / Somnia)."
+            "eth_gasPrice / eth_maxPriorityFeePerGas values. Defaults to "
+            "1s across every chain; the background loop is idle-aware "
+            "and skips refreshes when the cache hasn't been read in "
+            "3 * interval seconds, so a shorter interval on a quiet "
+            "bundler costs nothing."
         ),
         nargs="?",
         default=_get_env_or_default(
@@ -1109,12 +1110,13 @@ async def get_init_data(args: Namespace) -> InitData:
             ethereum_node_urls_rearranged[0], args.disable_v6)
 
     # Warm the gas-price cache synchronously so a misconfigured eth node
-    # URL fails at startup instead of on the first userop. The CLI override
-    # takes precedence over the per-chain default; both are positive floats.
+    # URL fails at startup instead of on the first userop. The CLI
+    # override takes precedence over the built-in default; both are
+    # positive floats.
     gas_price_refresh_interval = (
         args.gas_price_refresh_interval
         if args.gas_price_refresh_interval is not None
-        else default_refresh_interval(args.chain_id)
+        else DEFAULT_REFRESH_INTERVAL_SECONDS
     )
     gas_price_cache = GasPriceCache(
         ethereum_node_urls_rearranged,

--- a/voltaire_bundler/gas/gas_price_cache.py
+++ b/voltaire_bundler/gas/gas_price_cache.py
@@ -118,6 +118,12 @@ class GasPriceCache:
         # produce N concurrent RPC calls.
         self._lock = asyncio.Lock()
         self._stop = asyncio.Event()
+        # Monotonic clock timestamp of the most recent get_snapshot()
+        # call. Used by run() to skip the background refresh during
+        # idle periods (no consumer reading the cache). 0.0 = never
+        # read yet, treated as "idle" so a freshly-started bundler
+        # with no traffic doesn't burn RPCs.
+        self._last_read_at_monotonic: float = 0.0
 
     # ------------------------------------------------------------------ read
     async def get_snapshot(self) -> GasPriceSnapshot:
@@ -125,6 +131,12 @@ class GasPriceCache:
         happened in the last ``3 * interval`` seconds, perform a synchronous
         one-shot fetch first so consumers never see arbitrarily stale data.
         """
+        # Record the read timestamp BEFORE any await so run()'s idle
+        # check reflects consumer intent — a caller that's about to
+        # block on the lock still counts as "someone is reading" and
+        # keeps the background refresh loop active on the next tick.
+        self._last_read_at_monotonic = time.monotonic()
+
         snap = self._snapshot
         if snap is not None and not self._is_stale(snap):
             return snap
@@ -134,9 +146,14 @@ class GasPriceCache:
             # while we were waiting.
             snap = self._snapshot
             if snap is None or self._is_stale(snap):
-                logging.warning(
-                    "GasPriceCache stale (background loop dead or starved); "
-                    "performing synchronous fallback fetch."
+                # Not necessarily an error state — this also fires after
+                # an idle-triggered skip in run() when traffic resumes.
+                # Info-level: operators can still see it, but it doesn't
+                # look like a background-loop failure the way a warning
+                # would.
+                logging.info(
+                    "GasPriceCache: snapshot stale or absent; "
+                    "fetching synchronously."
                 )
                 await self._refresh()
                 snap = self._snapshot
@@ -158,7 +175,16 @@ class GasPriceCache:
 
     async def run(self) -> None:
         """Background refresh loop. Designed to be a child of the main
-        TaskGroup — cancellation propagates naturally."""
+        TaskGroup — cancellation propagates naturally.
+
+        Idle-aware: skips the refresh RPC when no consumer has read
+        the snapshot in the last ``3 * interval`` seconds. This aligns
+        with the staleness bound used by ``get_snapshot`` — the next
+        reader after an idle stretch will find the snapshot stale and
+        trigger the synchronous fallback, which repopulates the cache
+        and resets the idle timer. Net effect: background RPC load
+        scales with consumer demand instead of running as a flat
+        baseline on quiet chains."""
         while not self._stop.is_set():
             try:
                 # Sleep ``interval`` seconds, or wake early on stop.
@@ -168,6 +194,20 @@ class GasPriceCache:
                 return  # stop was set
             except asyncio.TimeoutError:
                 pass
+            # Idle skip: if the snapshot hasn't been read in
+            # ``3 * interval`` seconds, don't refresh. The synchronous
+            # fallback in get_snapshot handles the transition back to
+            # active without any coordination — it fires on the first
+            # read whose snapshot is stale, and updates
+            # _last_read_at_monotonic before returning, so the next
+            # tick sees a recent read and refreshes normally.
+            #
+            # 0.0 means "never read" (initial state after warm() +
+            # start of run()) — treated as idle so a bundler with no
+            # traffic yet doesn't burn RPCs on empty background ticks.
+            idle_for = time.monotonic() - self._last_read_at_monotonic
+            if idle_for > 3 * self._interval:
+                continue
             try:
                 # Hold the same lock as the synchronous-fallback path so
                 # the two refreshes can't race: without it, a slow

--- a/voltaire_bundler/gas/gas_price_cache.py
+++ b/voltaire_bundler/gas/gas_price_cache.py
@@ -35,9 +35,18 @@ from voltaire_bundler.utils.eth_client_utils import \
 # gives the tightest staleness bound (3 * interval = 3 s) so the sync
 # fallback after any idle stretch fires against a fresh snapshot, and
 # fast L2s (Arbitrum, HyperEVM, Somnia) already ran at this cadence
-# before. Operators who want a slower cadence for a specific chain can
-# still override via --gas_price_refresh_interval or
-# VOLTAIRE_GAS_PRICE_REFRESH_INTERVAL.
+# before.
+#
+# Tradeoff on busy, slow-block chains: under continuous reads (a
+# bundler serving traffic) the loop refreshes every interval regardless
+# of block time. On mainnet that's ~10x more eth_gasPrice /
+# eth_maxPriorityFeePerGas calls per active second than the previous
+# 10 s cadence, and 9 of 10 return the same value (gas can't change
+# faster than a 12 s block). Operators on metered eth-node providers,
+# or those running high-throughput mainnet bundlers, should raise this
+# via --gas_price_refresh_interval or
+# VOLTAIRE_GAS_PRICE_REFRESH_INTERVAL; both accept a positive float and
+# take precedence over this default.
 DEFAULT_REFRESH_INTERVAL_SECONDS = 1.0
 
 # Chains where ``eth_maxPriorityFeePerGas`` is not available. ``--legacy_mode``
@@ -162,9 +171,16 @@ class GasPriceCache:
         with the staleness bound used by ``get_snapshot`` — the next
         reader after an idle stretch will find the snapshot stale and
         trigger the synchronous fallback, which repopulates the cache
-        and resets the idle timer. Net effect: background RPC load
-        scales with consumer demand instead of running as a flat
-        baseline on quiet chains."""
+        and resets the idle timer.
+
+        Under continuous reads (a bundler actively serving traffic)
+        the idle branch never fires, so refresh happens every
+        ``interval`` regardless of the chain's block time. On busy
+        mainnet at the flat 1 s default this means ~1 refresh/sec
+        even though gas can't change faster than a 12 s block; raise
+        ``--gas_price_refresh_interval`` /
+        ``VOLTAIRE_GAS_PRICE_REFRESH_INTERVAL`` if that RPC volume
+        is a problem."""
         while not self._stop.is_set():
             try:
                 # Sleep ``interval`` seconds, or wake early on stop.

--- a/voltaire_bundler/gas/gas_price_cache.py
+++ b/voltaire_bundler/gas/gas_price_cache.py
@@ -28,41 +28,21 @@ from voltaire_bundler.utils.eth_client_utils import \
     send_rpc_request_to_eth_client
 
 
-# Per-chain refresh cadence (seconds). Picked to track each chain's typical
-# block time: gas price doesn't change between blocks, so refreshing faster
-# than the block rate is wasted work; refreshing slower means the cache lags
-# real conditions during fee spikes and risks rejecting legitimate userops
-# (or accepting underpriced ones that then fail bundle inclusion).
-_REFRESH_INTERVAL_BY_CHAIN: dict[int, float] = {
-    1: 10.0,            # Ethereum mainnet (12s blocks)
-    11155111: 10.0,     # Sepolia
-    137: 2.0,           # Polygon
-    80002: 2.0,         # Polygon Amoy
-    10: 2.0,            # Optimism
-    11155420: 2.0,      # OP Sepolia
-    8453: 2.0,          # Base
-    84532: 2.0,         # Base Sepolia
-    480: 2.0,           # World Chain
-    4801: 2.0,          # World Chain Sepolia
-    42161: 1.0,         # Arbitrum One (250ms blocks)
-    421614: 1.0,        # Arbitrum Sepolia
-    999: 1.0,           # HyperEVM
-    998: 1.0,           # HyperEVM testnet
-    5031: 1.0,          # Somnia
-    50312: 1.0,         # Somnia testnet
-    1337: 1.0,          # local anvil / dev
-}
-_DEFAULT_REFRESH_INTERVAL_SECONDS = 5.0
+# Uniform 1-second refresh cadence across every chain. Rationale: with
+# the idle-aware skip in run(), background RPC load already scales with
+# consumer demand rather than running as a flat baseline — a quiet
+# bundler makes zero refresh calls regardless of interval. Picking 1 s
+# gives the tightest staleness bound (3 * interval = 3 s) so the sync
+# fallback after any idle stretch fires against a fresh snapshot, and
+# fast L2s (Arbitrum, HyperEVM, Somnia) already ran at this cadence
+# before. Operators who want a slower cadence for a specific chain can
+# still override via --gas_price_refresh_interval or
+# VOLTAIRE_GAS_PRICE_REFRESH_INTERVAL.
+DEFAULT_REFRESH_INTERVAL_SECONDS = 1.0
 
 # Chains where ``eth_maxPriorityFeePerGas`` is not available. ``--legacy_mode``
 # also disables the call (handled at construction time).
 _CHAINS_WITHOUT_PRIORITY_FEE: frozenset[int] = frozenset({999, 998})
-
-
-def default_refresh_interval(chain_id: int) -> float:
-    return _REFRESH_INTERVAL_BY_CHAIN.get(
-        chain_id, _DEFAULT_REFRESH_INTERVAL_SECONDS
-    )
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gas price refreshing now defaults to a consistent 1-second interval when you don’t provide a custom refresh setting.

* **Bug Fixes**
  * The gas price cache refresh loop is now idle-aware, skipping unnecessary background updates when there’s no demand.
  * After idle periods, gas price data refreshes more reliably to ensure consumers receive up-to-date snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->