### PR TITLE
fix(gas): decode revert data instead of returning raw bytes repr

### DIFF
--- a/voltaire_bundler/gas/gas_manager_v6.py
+++ b/voltaire_bundler/gas/gas_manager_v6.py
@@ -11,7 +11,7 @@ from voltaire_bundler.gas.gas_price_cache import GasPriceCache
 from voltaire_bundler.custom_types import Address
 from voltaire_bundler.user_operation.models import FailedOp
 from voltaire_bundler.user_operation.user_operation_handler import \
-        decode_failed_op_event
+        decode_failed_op_event, decode_revert_bytes
 from voltaire_bundler.utils.load_bytecode import load_bytecode
 from ..user_operation.user_operation_v6 import UserOperationV6
 from voltaire_bundler.user_operation.user_operation_v6 import \
@@ -156,7 +156,7 @@ class GasManagerV6(GasManager):
                 error_message = failed_op_params_res[0]
                 raise ExecutionException(
                     ExecutionExceptionCode.UserOperationReverted,
-                    str(bytes([b for b in error_message if b != 0]))  # remove zero bytes from error message
+                    decode_revert_bytes(bytes(error_message)),
                 )
         # this should not be reached
         logging.critical(
@@ -296,9 +296,10 @@ class GasManagerV6(GasManager):
                 reason[0],
             )
         else:
+            revert_bytes = bytes.fromhex(error_selector[2:] + error_params)
             raise ValidationException(
                 ValidationExceptionCode.SimulateValidation,
-                error_params,
+                decode_revert_bytes(revert_bytes),
             )
         error_params_decoded = list(decode(
                 error_params_api, bytes.fromhex(error_params)))

--- a/voltaire_bundler/gas/gas_manager_v7v8v9.py
+++ b/voltaire_bundler/gas/gas_manager_v7v8v9.py
@@ -13,7 +13,8 @@ from voltaire_bundler.gas.gas_price_cache import GasPriceCache
 from voltaire_bundler.custom_types import Address
 from voltaire_bundler.user_operation.models import FailedOp, FailedOpWithRevert
 from voltaire_bundler.user_operation.user_operation_handler import \
-    decode_failed_op_event, decode_failed_op_with_revert_event
+    decode_failed_op_event, decode_failed_op_with_revert_event, \
+    decode_revert_bytes
 from voltaire_bundler.utils.load_bytecode import load_bytecode
 from ..user_operation.user_operation_v7v8v9 import UserOperationV7V8V9
 from ..user_operation.user_operation_v7v8v9 import pack_user_operation_with_signature
@@ -165,7 +166,7 @@ class GasManagerV7V8V9(GasManager):
                 error_message = failed_op_params_res[0]
                 raise ExecutionException(
                     ExecutionExceptionCode.UserOperationReverted,
-                    str(bytes([b for b in error_message if b != 0]))  # remove zero bytes from error message
+                    decode_revert_bytes(bytes(error_message)),
                 )
 
         raise ValueError(
@@ -289,9 +290,10 @@ class GasManagerV7V8V9(GasManager):
                 error_params
             )
 
+            decoded_inner = decode_revert_bytes(bytes(inner))
             raise ValidationException(
                 ValidationExceptionCode.SimulateValidation,
-                reason + str(bytes([b for b in inner if b != 0]))
+                f"{reason}: {decoded_inner}" if reason else decoded_inner,
             )
 
         elif error_selector == FailedOp.SELECTOR:
@@ -313,9 +315,10 @@ class GasManagerV7V8V9(GasManager):
                 reason[0],
             )
         else:
+            revert_bytes = bytes.fromhex(error_selector[2:] + error_params)
             raise ValidationException(
                 ValidationExceptionCode.SimulateValidation,
-                error_params,
+                decode_revert_bytes(revert_bytes),
             )
         error_params_decoded = list(decode(
                 error_params_api, bytes.fromhex(error_params)))

--- a/voltaire_bundler/user_operation/user_operation_handler.py
+++ b/voltaire_bundler/user_operation/user_operation_handler.py
@@ -1071,7 +1071,6 @@ PANIC_REASONS = {
 }
 
 
-@cache
 def decode_revert_bytes(revert_data: bytes) -> str:
     """Best-effort decode of raw revert data (Error(string), Panic(uint256),
     or an unrecognized selector) into a human-readable message."""

--- a/voltaire_bundler/user_operation/user_operation_handler.py
+++ b/voltaire_bundler/user_operation/user_operation_handler.py
@@ -1057,6 +1057,43 @@ async def get_transaction_by_hash(
         return None
 
 
+PANIC_REASONS = {
+    0x00: "generic panic",
+    0x01: "assertion failed",
+    0x11: "arithmetic overflow/underflow",
+    0x12: "division or modulo by zero",
+    0x21: "invalid enum value",
+    0x22: "storage byte array incorrectly encoded",
+    0x31: "pop() called on empty array",
+    0x32: "array index out of bounds",
+    0x41: "out of memory / too large allocation",
+    0x51: "call to a zero-initialized variable of internal function type",
+}
+
+
+@cache
+def decode_revert_bytes(revert_data: bytes) -> str:
+    """Best-effort decode of raw revert data (Error(string), Panic(uint256),
+    or an unrecognized selector) into a human-readable message."""
+    if len(revert_data) == 0:
+        return "no revert data"
+
+    selector, params = revert_data[:4], revert_data[4:]
+    try:
+        if selector == bytes.fromhex("08c379a0"):  # Error(string)
+            reason: str = decode(["string"], params)[0]
+            return reason
+        elif selector == bytes.fromhex("4e487b71"):  # Panic(uint256)
+            code: int = decode(["uint256"], params)[0]
+            return (
+                f"panic: {PANIC_REASONS.get(code, 'unknown panic code')} "
+                f"(0x{code:02x})"
+            )
+    except Exception:
+        pass
+    return f"unknown revert (selector 0x{selector.hex()}): 0x{revert_data.hex()}"
+
+
 @cache
 def decode_failed_op_event(solidity_error_params: str) -> tuple[int, str]:
     FAILED_OP_PARAMS_API = ["uint256", "string"]


### PR DESCRIPTION
## Summary
- `eth_estimateUserOperationGas` was returning undecoded revert payloads as a Python `bytes` repr (e.g. `"b'\xbc\xder#...'"`) instead of a readable message, in three spots in `gas_manager_v6.py`/`gas_manager_v7v8v9.py` where raw ABI `bytes` were passed through `str(bytes([...]))` instead of being decoded.
- Added `decode_revert_bytes()` in `user_operation_handler.py`, which decodes `Error(string)` and `Panic(uint256)` (with named panic reasons — array OOB, div by zero, overflow, etc.) and falls back to a clean `unknown revert (selector 0x...): 0x<hex>` message for unrecognized/custom errors instead of the bytes repr.
- Wired the decoder into the `EstimateCallGasRevertAtMax` branch, the `FailedOpWithRevert.inner` field, and the unrecognized-selector fallback in both gas managers.

## Test plan
- [x] `poetry run flake8`/`mypy` on touched files — no new lint/type errors (verified against baseline on `dev`)
- [x] `poetry run pytest -k "gas or revert or error"` — no new failures (pre-existing failures on `dev` are unrelated: Docker-dependent test, iaccount_execute assertion)
- [x] Live end-to-end verification against a local Anvil + bundler: deployed a mock account contract that reverts with `require(false, "custom test revert reason")` and via array-out-of-bounds (`Panic(0x32)`), and called the real `eth_estimateUserOperationGas` RPC endpoint on both old and new code to confirm the fix:
  - Before: `"b'\x08\xc3y\xa0 \x19custom test revert reason'"` / `"b'NH{q2'"`
  - After: `"custom test revert reason"` / `"panic: array index out of bounds (0x32)"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gas estimation failure handling by decoding revert data into readable execution messages.
  * Added best-effort revert decoding for standard Solidity errors (`Error(string)`) and `Panic(uint256)`, producing human-friendly panic details.
  * Enhanced validation errors for failed operations, including clearer output for empty, unknown, or malformed revert data with informative fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->