### PR TITLE
feat(validation): use pre-deployed simulation contracts when available

### DIFF
--- a/voltaire_bundler/execution_endpoint.py
+++ b/voltaire_bundler/execution_endpoint.py
@@ -30,6 +30,7 @@ from voltaire_bundler.user_operation.user_operation_handler import \
     fell_user_operation_optional_parameters_for_estimateUserOperationGas
 from voltaire_bundler.gas.gas_price_cache import GasPriceCache
 from voltaire_bundler.utils.cache import PersistentFIFOCache
+from voltaire_bundler.utils.deployed_simulations import check_deployed_simulations
 from voltaire_bundler.utils.eth_client_utils import get_block_info, send_rpc_request_to_eth_client
 
 from .bundle.bundle_manager import BundlerManager
@@ -376,7 +377,31 @@ class ExecutionEndpoint(Endpoint):
 
                 self.peer_ids_to_user_ops_hashes_queue[peer_id] = []
 
+    async def init_deployed_simulations(self) -> None:
+        """Check at boot if the simulation contracts are pre-deployed at
+        their canonical deterministic addresses (logging the result per
+        contract) and, if so, have the validation managers use a tiny
+        delegatecall-proxy code override pointing at the deployed contract
+        instead of the full ~40KB simulation bytecode on every eth_call."""
+        deployed_overrides = await check_deployed_simulations(
+            self.ethereum_node_urls, self.chain_id, self.disable_v6
+        )
+        if not deployed_overrides:
+            return
+        validation_managers = [
+            self.local_mempool_manager_v9.validation_manager,
+            self.local_mempool_manager_v8.validation_manager,
+            self.local_mempool_manager_v7.validation_manager,
+        ]
+        if self.local_mempool_manager_v6 is not None:
+            validation_managers.append(
+                self.local_mempool_manager_v6.validation_manager)
+        for validation_manager in validation_managers:
+            validation_manager.deployed_simulations_overrides.update(
+                deployed_overrides)
+
     async def start_execution_endpoint(self) -> None:
+        await self.init_deployed_simulations()
         self.add_events_and_response_functions_by_prefix(
             prefix="_event_", decorator_func=exception_handler_decorator
         )

--- a/voltaire_bundler/utils/deployed_simulations.py
+++ b/voltaire_bundler/utils/deployed_simulations.py
@@ -1,0 +1,129 @@
+import logging
+
+from voltaire_bundler.utils.eth_client_utils import \
+    send_rpc_request_to_eth_client
+from voltaire_bundler.utils.load_bytecode import load_bytecode
+
+# Canonical CREATE2 addresses of the pre-deployed EntryPoint simulation
+# contracts (see the voltaire-sim-deployer project). They are deployed through
+# the deterministic-deployment proxy 0x4e59b44847b379578588920cA78FbF26c0B4956C
+# (the same factory the EntryPoint uses) with the salt
+# keccak256("voltaire.entrypoint.simulations.v1"), so the addresses are
+# identical on every chain. The deployed code is byte-identical to the runtime
+# bytecode bundled in voltaire_bundler/contracts/*.json.
+DEPLOYED_SIMULATIONS_ADDRESSES: dict[str, str] = {
+    "EntryPointSimulationsV6": "0x22f87463FB44061C5D5949535177a6ccd8cEc4bA",
+    "EntryPointSimulationsV6Arb": "0xE06533B364DA907F8E75909A2FB90d2C80FA48Fc",
+    "EntryPointSimulationsV7": "0xbdA6700BC1A485Dc6E965bf6771E03c5820daa6D",
+    "EntryPointSimulationsV7Arb": "0x54Ac13CE92b748a75C4fD563b0A2A070d4C0e2E1",
+    "EntryPointSimulationsV8": "0xc350d92dd8E9e4f9aaC6B9E590820BC21999D050",
+    "EntryPointSimulationsV8Arb": "0xB75F762E25d9DF772C44E34aD5c9dF71948Ae4f6",
+    "EntryPointSimulationsV9": "0x70d62534631aF6548521c22Ed71d09d1E744518a",
+    "EntryPointSimulationsModV9Arb": "0xC3f016A494F4F1e70b0526e8eB9996be775e23b8",
+}
+
+ENTRYPOINT_V6_LOWERCASE = "0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789"
+ENTRYPOINT_V7_LOWERCASE = "0x0000000071727de22e5e9d8baf0edac6f37da032"
+ENTRYPOINT_V8_LOWERCASE = "0x4337084d9e255ff0702461cf8895ce9e3b5ff108"
+ENTRYPOINT_V9_LOWERCASE = "0x433709009b8330fda32311df1c2afa402ed8d009"
+
+
+def delegatecall_proxy_runtime(target: str) -> str:
+    """EIP-1167-style runtime bytecode that DELEGATECALLs `target`,
+    forwarding calldata and bubbling up return data/reverts.
+
+    Used as a ~45 byte eth_call code override at the EntryPoint address
+    instead of the full ~40KB simulation runtime once the simulation
+    contract is found pre-deployed on-chain. Delegatecall keeps
+    address(this) = EntryPoint and the EntryPoint's storage, so execution
+    is semantically identical to overriding with the full bytecode (and,
+    for v0.9, does not trip the EntryPoint's contract-caller guard the way
+    a separate-address CALL proxy would).
+    """
+    return (
+        "0x363d3d373d3d3d363d73"
+        + target.lower().removeprefix("0x")
+        + "5af43d82803e903d91602b57fd5bf3"
+    )
+
+
+async def check_deployed_simulations(
+    ethereum_node_urls: list[str],
+    chain_id: int,
+    disable_v6: bool,
+) -> dict[str, str]:
+    """Check at boot whether the simulation contracts used for validation on
+    this chain are pre-deployed at their canonical addresses, logging the
+    result for each. Returns a mapping of entrypoint address (lowercase) to a
+    delegatecall-proxy code override for every simulation contract that is
+    deployed with the expected bytecode; entrypoints whose simulation contract
+    is missing (or mismatched) are absent, and validation falls back to the
+    full bytecode state override for them.
+    """
+    # arbitrum One or arbitrum sepolia use the Arb simulation variants
+    # for validation, mirror that here
+    is_arb = chain_id == 42161 or chain_id == 421614
+    checks: list[tuple[str, str]] = []
+    if not disable_v6:
+        checks.append((
+            ENTRYPOINT_V6_LOWERCASE,
+            "EntryPointSimulationsV6Arb" if is_arb
+            else "EntryPointSimulationsV6",
+        ))
+    checks += [
+        (
+            ENTRYPOINT_V7_LOWERCASE,
+            "EntryPointSimulationsV7Arb" if is_arb
+            else "EntryPointSimulationsV7",
+        ),
+        (
+            ENTRYPOINT_V8_LOWERCASE,
+            "EntryPointSimulationsV8Arb" if is_arb
+            else "EntryPointSimulationsV8",
+        ),
+        (
+            ENTRYPOINT_V9_LOWERCASE,
+            "EntryPointSimulationsModV9Arb" if is_arb
+            else "EntryPointSimulationsV9",
+        ),
+    ]
+
+    overrides: dict[str, str] = {}
+    for entrypoint_lowercase, contract_name in checks:
+        address = DEPLOYED_SIMULATIONS_ADDRESSES[contract_name]
+        try:
+            result = await send_rpc_request_to_eth_client(
+                ethereum_node_urls, "eth_getCode", [address, "latest"]
+            )
+            onchain_code = result.get("result")
+        except Exception:
+            logging.warning(
+                f"eth_getCode failed while checking if {contract_name} is "
+                f"deployed at {address} - falling back to the full bytecode "
+                "state override for validation."
+            )
+            continue
+
+        if onchain_code is None or len(onchain_code) <= 2:
+            logging.info(
+                f"{contract_name} is not deployed at {address} - using the "
+                "full bytecode state override for validation."
+            )
+            continue
+
+        expected_runtime = load_bytecode(f"{contract_name}.json")
+        if onchain_code.lower() != expected_runtime.lower():
+            logging.warning(
+                f"{contract_name} at {address} does not match the bundled "
+                "runtime bytecode - using the full bytecode state override "
+                "for validation."
+            )
+            continue
+
+        logging.info(
+            f"{contract_name} is deployed at {address} - using the deployed "
+            "simulation contract for validation (delegatecall override)."
+        )
+        overrides[entrypoint_lowercase] = delegatecall_proxy_runtime(address)
+
+    return overrides

--- a/voltaire_bundler/utils/deployed_simulations.py
+++ b/voltaire_bundler/utils/deployed_simulations.py
@@ -93,7 +93,10 @@ async def check_deployed_simulations(
         address = DEPLOYED_SIMULATIONS_ADDRESSES[contract_name]
         try:
             result = await send_rpc_request_to_eth_client(
-                ethereum_node_urls, "eth_getCode", [address, "latest"]
+                ethereum_node_urls,
+                "eth_getCode",
+                [address, "latest"],
+                expected_key="result",
             )
             onchain_code = result.get("result")
         except Exception:

--- a/voltaire_bundler/validation/validation_manager.py
+++ b/voltaire_bundler/validation/validation_manager.py
@@ -18,6 +18,12 @@ class ValidationManager(ABC, Generic[UserOperationType]):
     enforce_gas_price_tolerance: int
     enforce_pre_verification_gas_tolerance: int
     ethereum_node_debug_trace_call_urls: list[str]
+    # entrypoint address (lowercase) -> delegatecall-proxy code override
+    # pointing at a pre-deployed simulation contract. Populated at boot by
+    # ExecutionEndpoint.init_deployed_simulations for the simulation
+    # contracts found deployed on-chain; empty means always use the full
+    # bytecode state override.
+    deployed_simulations_overrides: dict[str, str]
 
     @abstractmethod
     async def validate_user_operation(

--- a/voltaire_bundler/validation/validation_manager_v6.py
+++ b/voltaire_bundler/validation/validation_manager_v6.py
@@ -60,6 +60,10 @@ class ValidationManagerV6(ValidationManager):
         self.entrypoint_code_override_arb = load_bytecode(
             "EntryPointSimulationsV6Arb.json")
 
+        # Populated at boot by ExecutionEndpoint.init_deployed_simulations
+        # when the simulation contracts are pre-deployed on-chain.
+        self.deployed_simulations_overrides: dict[str, str] = {}
+
 
     async def validate_user_operation(
         self,
@@ -236,23 +240,25 @@ class ValidationManagerV6(ValidationManager):
 
         # arbitrum One or arbitrum sepolia
         if self.chain_id == 42161 or self.chain_id == 421614:
-            state_overrides = {
-                # override the Entrypoint with EntryPointSimulationsV6Arb
-                entrypoint: {"code": self.entrypoint_code_override_arb},
-                self.bundler_address: {
-                    # override the bundler address balance with a high value
-                    "balance": "0x314dc6448d9338c15b0a00000000",
-                },
-            }
+            entrypoint_code_override = self.entrypoint_code_override_arb
         else:
-            state_overrides = {
-                # override the Entrypoint with EntryPointSimulationsV6
-                entrypoint: {"code": self.entrypoint_code_override},
-                self.bundler_address: {
-                    # override the bundler address balance with a high value
-                    "balance": "0x314dc6448d9338c15b0a00000000",
-                },
-            }
+            entrypoint_code_override = self.entrypoint_code_override
+        # If the simulation contract was found pre-deployed at boot, override
+        # with a tiny delegatecall proxy pointing at it instead of shipping
+        # the full ~40KB simulation bytecode on every eth_call. Delegatecall
+        # keeps address(this)/storage = EntryPoint, so execution is identical.
+        # Only the non-tracing path does this: an extra call frame would shift
+        # the depths BundlerCollectorTracer relies on in the tracing path.
+        entrypoint_code_override = self.deployed_simulations_overrides.get(
+            entrypoint.lower(), entrypoint_code_override)
+        state_overrides = {
+            # override the Entrypoint with EntryPointSimulations
+            entrypoint: {"code": entrypoint_code_override},
+            self.bundler_address: {
+                # override the bundler address balance with a high value
+                "balance": "0x314dc6448d9338c15b0a00000000",
+            },
+        }
 
         params = [
             {

--- a/voltaire_bundler/validation/validation_manager_v7v8v9.py
+++ b/voltaire_bundler/validation/validation_manager_v7v8v9.py
@@ -77,6 +77,10 @@ class ValidationManagerV7V8V9(ValidationManager):
         self.entrypoint_code_override_v9_arb = load_bytecode(
             "EntryPointSimulationsModV9Arb.json")
 
+        # Populated at boot by ExecutionEndpoint.init_deployed_simulations
+        # when the simulation contracts are pre-deployed on-chain.
+        self.deployed_simulations_overrides: dict[str, str] = {}
+
     async def validate_user_operation(
         self,
         user_operation: UserOperationV7V8V9,
@@ -250,6 +254,14 @@ class ValidationManagerV7V8V9(ValidationManager):
                 entrypoint_code_override = self.entrypoint_code_override_v7_arb
             else:
                 entrypoint_code_override = self.entrypoint_code_override_v7
+        # If the simulation contract was found pre-deployed at boot, override
+        # with a tiny delegatecall proxy pointing at it instead of shipping
+        # the full ~40KB simulation bytecode on every eth_call. Delegatecall
+        # keeps address(this)/storage = EntryPoint, so execution is identical.
+        # Only the non-tracing path does this: an extra call frame would shift
+        # the depths BundlerCollectorTracer relies on in the tracing path.
+        entrypoint_code_override = self.deployed_simulations_overrides.get(
+            entrypoint.lower(), entrypoint_code_override)
         state_overrides = {  # override the Entrypoint with EntryPointSimulations
             entrypoint: {"code": entrypoint_code_override},
             self.bundler_address: {


### PR DESCRIPTION
At boot, check whether the EntryPoint simulation contracts are deployed at their canonical deterministic CREATE2 addresses (same on every chain, via the 0x4e59... factory) and log the result per contract. When a contract is found with bytecode identical to the bundled runtime, the non-tracing validation path overrides the EntryPoint with a ~45-byte EIP-1167-style delegatecall proxy pointing at it instead of shipping the full ~40KB simulation bytecode on every eth_call.

Delegatecall keeps address(this)/storage = EntryPoint, so execution is semantically identical to the full-code override, and (for v0.9) does not trip the EntryPoint's contract-caller guard. Falls back to the full bytecode override when a contract is missing, mismatched, or the check fails. The tracing path keeps the full override: an extra call frame would shift the depths BundlerCollectorTracer relies on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced validation simulation overhead when compatible simulation contracts are already deployed on-chain.
  * Uses lightweight on-chain delegation (when available) to avoid loading full simulation bytecode.

* **Reliability**
  * Adds a startup check to detect pre-deployed simulation contracts and prepare per-entrypoint code overrides.
  * Validation continues with existing behavior if deployed bytecode is missing, mismatched, or cannot be verified.

* **New Features**
  * Introduces deployed simulation override support across validation flows (v6 through v7/v8/v9).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->