### PR TITLE
feat(gas): recommend accepting tolerance in gas-fee rejection debug logs

### DIFF
--- a/tests/test_gas_fee_tolerance_recommendation.py
+++ b/tests/test_gas_fee_tolerance_recommendation.py
@@ -1,0 +1,202 @@
+"""
+Tests for the debug recommendation emitted when
+GasManager.verify_gas_fees_and_get_price rejects a userop for a too-low
+maxFeePerGas: the log must name the smallest --enforce_gas_price_tolerance
+value that would have accepted the userop, and that value must actually
+invert the acceptance formula (recommended passes, recommended - 1 rejects).
+"""
+
+import logging
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from voltaire_bundler.user_operation.user_operation_v7v8v9 import (
+    UserOperationV7V8V9,
+)
+from voltaire_bundler.gas.gas_manager import _min_accepting_tolerance
+from voltaire_bundler.gas.gas_manager_v7v8v9 import GasManagerV7V8V9
+from voltaire_bundler.gas.gas_price_cache import (
+    GasPriceCache,
+    GasPriceSnapshot,
+)
+from voltaire_bundler.bundle.exceptions import ValidationException
+
+
+BUNDLER_ADDRESS = "0x0000000000000000000000000000000000000001"
+BLOCK_GAS_PRICE = 1_000_000_000  # 1 gwei node gas price
+
+
+def _make_gas_manager(chain_id: int) -> GasManagerV7V8V9:
+    return GasManagerV7V8V9(
+        ethereum_node_urls=["http://localhost:8545"],
+        chain_id=chain_id,
+        bundler_address=BUNDLER_ADDRESS,
+        is_legacy_mode=False,
+        max_verification_gas=1_000_000,
+        max_call_data_gas=1_000_000,
+        gas_price_cache=GasPriceCache(
+            ethereum_node_urls=["http://localhost:8545"],
+            chain_id=chain_id,
+            is_legacy_mode=False,
+            refresh_interval_seconds=1.0,
+        ),
+    )
+
+
+def _make_user_operation(
+    max_fee_per_gas: int, max_priority_fee_per_gas: int = 0,
+) -> UserOperationV7V8V9:
+    return UserOperationV7V8V9({
+        "sender": "0x7e25461EEE6853f89e5bA2bDf87F47a8965EbE04",
+        "nonce": "0x0",
+        "callData": "0x",
+        "callGasLimit": "0x0",
+        "verificationGasLimit": "0x0",
+        "preVerificationGas": "0x0",
+        "maxFeePerGas": hex(max_fee_per_gas),
+        "maxPriorityFeePerGas": hex(max_priority_fee_per_gas),
+        "signature": "0x" + "00" * 65,
+        "factory": None,
+        "factoryData": None,
+        "paymaster": None,
+        "paymasterVerificationGasLimit": None,
+        "paymasterPostOpGasLimit": None,
+        "paymasterData": None,
+        "eip7702Auth": None,
+    })
+
+
+def _snapshot(priority_fee: int | None) -> GasPriceSnapshot:
+    return GasPriceSnapshot(
+        max_fee_per_gas=BLOCK_GAS_PRICE,
+        max_priority_fee_per_gas=priority_fee,
+        fetched_at_monotonic=0.0,
+    )
+
+
+def _patched_snapshot(gm: GasManagerV7V8V9, priority_fee: int | None):
+    return patch.object(
+        gm.gas_price_cache, "get_snapshot",
+        new_callable=AsyncMock, return_value=_snapshot(priority_fee),
+    )
+
+
+# ------------------------------------------------------------------ helper
+
+
+def test_min_accepting_tolerance_edges():
+    # At or above the block price: no tolerance needed.
+    assert _min_accepting_tolerance(BLOCK_GAS_PRICE, BLOCK_GAS_PRICE) == 0
+    assert _min_accepting_tolerance(BLOCK_GAS_PRICE + 1, BLOCK_GAS_PRICE) == 0
+    # Tiny gap: smallest nonzero recommendation.
+    assert _min_accepting_tolerance(BLOCK_GAS_PRICE - 1, BLOCK_GAS_PRICE) == 1
+    # Huge gap: capped at 100.
+    assert _min_accepting_tolerance(1, BLOCK_GAS_PRICE) == 100
+    # Degenerate block price.
+    assert _min_accepting_tolerance(0, 0) == 0
+
+
+@pytest.mark.parametrize("fee_ratio_bp", [9999, 9500, 9001, 9000, 8999, 5000, 1])
+def test_min_accepting_tolerance_inverts_acceptance(fee_ratio_bp: int):
+    """Property: recommended t accepts; t - 1 (when >= 0) rejects."""
+    import math
+    effective_fee = BLOCK_GAS_PRICE * fee_ratio_bp // 10_000
+    t = _min_accepting_tolerance(effective_fee, BLOCK_GAS_PRICE)
+
+    def accepts(tol: int) -> bool:
+        return effective_fee >= math.ceil(BLOCK_GAS_PRICE * (1 - tol / 100))
+
+    assert accepts(t), (fee_ratio_bp, t)
+    if t > 0:
+        assert not accepts(t - 1), (fee_ratio_bp, t)
+
+
+# ----------------------------------------------------- site A1 (Arbitrum)
+
+
+@pytest.mark.asyncio
+async def test_arbitrum_rejection_logs_recommendation(caplog):
+    gm = _make_gas_manager(chain_id=42161)
+    # 85% of the node gas price with 10% tolerance -> rejected; needs 15%.
+    user_op = _make_user_operation(BLOCK_GAS_PRICE * 85 // 100)
+
+    with _patched_snapshot(gm, None):
+        with caplog.at_level(logging.DEBUG):
+            with pytest.raises(ValidationException) as excinfo:
+                await gm.verify_gas_fees_and_get_price(user_op, 10)
+
+    # Client-facing message unchanged.
+    assert excinfo.value.message.startswith(
+        "maxFeePerGas is too low. it should be minimum : ")
+    # Debug recommendation present and correct.
+    assert "a tolerance of at least 15%" in caplog.text
+    assert "chain 42161" in caplog.text
+
+    # Property check: recommended tolerance accepts, one less rejects.
+    with _patched_snapshot(gm, None):
+        await gm.verify_gas_fees_and_get_price(user_op, 15)
+        with pytest.raises(ValidationException):
+            await gm.verify_gas_fees_and_get_price(user_op, 14)
+
+
+# ------------------------------------------------- site B2 (EIP-1559 chain)
+
+
+@pytest.mark.asyncio
+async def test_eip1559_combined_rejection_logs_recommendation(caplog):
+    gm = _make_gas_manager(chain_id=11155111)
+    # Node: 1 gwei total, 0.2 gwei priority -> base 0.8 gwei. Userop:
+    # high maxFeePerGas but zero priority -> effective = base = 80% of
+    # block price; with 10% tolerance -> rejected; needs 20%.
+    user_op = _make_user_operation(
+        BLOCK_GAS_PRICE * 2, max_priority_fee_per_gas=0)
+
+    with _patched_snapshot(gm, BLOCK_GAS_PRICE * 20 // 100):
+        with caplog.at_level(logging.DEBUG):
+            with pytest.raises(ValidationException) as excinfo:
+                await gm.verify_gas_fees_and_get_price(user_op, 10)
+
+    assert excinfo.value.message.startswith(
+        "maxFeePerGas and (maxPriorityFeePerGas + estimated basefee) ")
+    assert "a tolerance of at least 20%" in caplog.text
+    assert "chain 11155111" in caplog.text
+
+    # Property check.
+    with _patched_snapshot(gm, BLOCK_GAS_PRICE * 20 // 100):
+        await gm.verify_gas_fees_and_get_price(user_op, 20)
+        with pytest.raises(ValidationException):
+            await gm.verify_gas_fees_and_get_price(user_op, 19)
+
+
+# --------------------------------------------- site B1 (below base fee)
+
+
+@pytest.mark.asyncio
+async def test_below_base_fee_logs_no_tolerance_helps(caplog):
+    gm = _make_gas_manager(chain_id=11155111)
+    # Base fee is 0.8 gwei; userop maxFeePerGas below it.
+    user_op = _make_user_operation(BLOCK_GAS_PRICE * 50 // 100)
+
+    with _patched_snapshot(gm, BLOCK_GAS_PRICE * 20 // 100):
+        with caplog.at_level(logging.DEBUG):
+            with pytest.raises(ValidationException) as excinfo:
+                await gm.verify_gas_fees_and_get_price(user_op, 10)
+
+    assert "estimated base fee" in excinfo.value.message
+    assert "no --enforce_gas_price_tolerance value helps" in caplog.text
+
+
+# ------------------------------------------------------- accepted: silent
+
+
+@pytest.mark.asyncio
+async def test_accepted_userop_logs_nothing(caplog):
+    gm = _make_gas_manager(chain_id=42161)
+    user_op = _make_user_operation(BLOCK_GAS_PRICE)
+
+    with _patched_snapshot(gm, None):
+        with caplog.at_level(logging.DEBUG):
+            await gm.verify_gas_fees_and_get_price(user_op, 10)
+
+    assert "gas-fee rejection" not in caplog.text

--- a/voltaire_bundler/gas/gas_manager.py
+++ b/voltaire_bundler/gas/gas_manager.py
@@ -17,6 +17,23 @@ from voltaire_bundler.utils.eth_client_utils import \
     encode_handleops_calldata_v6, encode_handleops_calldata_v7v8v9, send_rpc_request_to_eth_client
 
 
+def _min_accepting_tolerance(effective_fee: int, block_max_fee: int) -> int:
+    """Smallest integer tolerance % for which ``effective_fee`` passes the
+    gas-fee check ``effective_fee >= ceil(block_max_fee * (1 - t/100))``.
+    Used only for the operator-facing debug recommendation on rejection."""
+    if block_max_fee <= 0:
+        return 0
+    # Evaluate the check's own formula for each candidate rather than
+    # inverting it in closed form: float rounding in ``1 - t/100`` makes
+    # an algebraic inversion off-by-one near exact percentages, while
+    # this scan is minimal-by-construction and runs only on the (rare)
+    # rejection path — at most 100 cheap iterations.
+    for t in range(0, 100):
+        if effective_fee >= math.ceil(block_max_fee * (1 - t / 100)):
+            return t
+    return 100
+
+
 class GasManager(ABC, Generic[UserOperationType]):
     ethereum_node_urls: list[str]
     chain_id: int
@@ -65,6 +82,19 @@ class GasManager(ABC, Generic[UserOperationType]):
             else:  # HyperEVM or Arbitrum
                 block_max_priority_fee_per_gas = 0
             if max_fee_per_gas < block_max_fee_per_gas_with_tolerance:
+                logging.debug(
+                    "gas-fee rejection on chain %s: maxFeePerGas=%s < "
+                    "min=%s (node gas price %s, tolerance %s%%); a "
+                    "tolerance of at least %s%% "
+                    "(--enforce_gas_price_tolerance) would have accepted "
+                    "this userop",
+                    self.chain_id, hex(max_fee_per_gas),
+                    block_max_fee_per_gas_with_tolerance_hex,
+                    hex(block_max_fee_per_gas), enforce_gas_price_tolerance,
+                    _min_accepting_tolerance(
+                        max_fee_per_gas, block_max_fee_per_gas,
+                    ),
+                )
                 raise ValidationException(
                     ValidationExceptionCode.InvalidFields,
                     "maxFeePerGas is too low. it should be minimum : " +
@@ -85,19 +115,42 @@ class GasManager(ABC, Generic[UserOperationType]):
             )
 
             if max_fee_per_gas < estimated_base_fee:
+                logging.debug(
+                    "gas-fee rejection on chain %s: maxFeePerGas=%s is "
+                    "below the estimated base fee %s itself — no "
+                    "--enforce_gas_price_tolerance value helps here (the "
+                    "sender must raise maxFeePerGas; only tolerance >= "
+                    "100 would bypass, by disabling the check entirely)",
+                    self.chain_id, hex(max_fee_per_gas),
+                    hex(estimated_base_fee),
+                )
                 raise ValidationException(
                     ValidationExceptionCode.InvalidFields,
                     "maxFeePerGas is too low." +
                     "it should be minimum the estimated base fee: " +
                     f"{hex(estimated_base_fee)}",
                 )
-            if (
-                min(
-                    max_fee_per_gas,
-                    estimated_base_fee + max_priority_fee_per_gas,
+            effective_fee = min(
+                max_fee_per_gas,
+                estimated_base_fee + max_priority_fee_per_gas,
+            )
+            if effective_fee < block_max_fee_per_gas_with_tolerance:
+                logging.debug(
+                    "gas-fee rejection on chain %s: min(maxFeePerGas=%s, "
+                    "estimatedBaseFee=%s + maxPriorityFeePerGas=%s) = %s "
+                    "< min=%s (node gas price %s, tolerance %s%%); a "
+                    "tolerance of at least %s%% "
+                    "(--enforce_gas_price_tolerance) would have accepted "
+                    "this userop",
+                    self.chain_id, hex(max_fee_per_gas),
+                    hex(estimated_base_fee), hex(max_priority_fee_per_gas),
+                    hex(effective_fee),
+                    block_max_fee_per_gas_with_tolerance_hex,
+                    hex(block_max_fee_per_gas), enforce_gas_price_tolerance,
+                    _min_accepting_tolerance(
+                        effective_fee, block_max_fee_per_gas,
+                    ),
                 )
-                < block_max_fee_per_gas_with_tolerance
-            ):
                 raise ValidationException(
                     ValidationExceptionCode.InvalidFields,
                     "maxFeePerGas and (maxPriorityFeePerGas + estimated basefee) " +


### PR DESCRIPTION
"maxFeePerGas is too low" rejections were returned to clients with no server-side trace, leaving operators unable to tell what --enforce_gas_price_tolerance value would stop the noise. Each of the three rejection sites in verify_gas_fees_and_get_price now emits a logging.debug line (visible with --verbose) carrying the chain id, the userop's fees, the node gas price, the current tolerance, and the smallest tolerance that would have accepted the userop — computed by _min_accepting_tolerance, which scans candidates against the check's own acceptance expression (a closed-form inversion is off-by-one near exact percentages due to float rounding). The below-base-fee site states explicitly that no tolerance value helps. Client-facing error messages are byte-for-byte unchanged.

Property-tested: the recommended value passes the check and recommended - 1 still rejects, for both the legacy/Arbitrum and EIP-1559 branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gas-fee rejection diagnostics with clearer details for legacy and EIP-1559-compatible networks.
  * Added recommendations for the minimum gas-fee tolerance needed when an operation is rejected.
  * Improved handling of cases where no tolerance adjustment can resolve the rejection.

* **Tests**
  * Added coverage for tolerance boundaries, acceptance behavior, network-specific rejection scenarios, and silently accepted operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->